### PR TITLE
add dictutil.attrdict() for access dictionary items with object attribute

### DIFF
--- a/dictutil/README.md
+++ b/dictutil/README.md
@@ -111,9 +111,19 @@ for record in records:
 ## dictutil.attrdict
 
 **syntax**:
-`dictutil.attrdict([{...}], [<key>=<value>...])`
+`dictutil.attrdict()`
 
-Make an object and let it can be accessed with attribute.
+**syntax**:
+`dictutil.attrdict(mapping, **kwargs)`:<br/>
+new dictionary initialized from a mapping object's (key, value) pairs, with additional name=value pairs.
+
+**syntax**:
+`dictutil.attrdict(iterable, **kwargs)`:<br/>
+new dictionary initialized as if via: `d = {}; for k, v in iterable: d[k] = v`
+
+Make a dict-like object whose keys can also be accessed with attribute.
+
+Argument is exactly the same as `dict()`.
 
 ```
 a = dictutil.attrdict(x=3, y={'z':4})

--- a/dictutil/README.md
+++ b/dictutil/README.md
@@ -6,6 +6,7 @@
 - [Status](#status)
 - [Synopsis](#synopsis)
 - [Methods](#methods)
+  - [dictutil.attrdict](#dictutilattrdict)
   - [dictutil.depth_iter](#dictutildepth_iter)
   - [dictutil.breadth_iter](#dictutilbreadth_iter)
   - [dictutil.make_getter](#dictutilmake_getter)
@@ -106,6 +107,61 @@ for record in records:
 ```
 
 #   Methods
+
+## dictutil.attrdict
+
+**syntax**:
+`dictutil.attrdict([{...}], [<key>=<value>...])`
+
+Make an object and let it can be accessed with attribute.
+
+```
+a = dictutil.attrdict(x=3, y={'z':4})
+a['x']  # 3
+a.x     # 3
+a.y     # {'z':4}
+a.y.z   # 4
+```
+
+This funciton also works well with circular references.
+
+```
+x = {}
+x['x'] = x
+ad = dictutil.attrdict(x)
+
+print(ad.x is ad) # True: circular references are kept
+```
+
+Pros:
+
+- It actually works!
+- No dictionary class methods are shadowed (e.g. .keys() work just fine)
+- Attributes and items are always in sync
+- Trying to access non-existent key as an attribute correctly raises AttributeError instead of KeyError
+
+Cons:
+
+- Methods like .keys() will not work just fine if they get overwritten by incoming data
+- Causes a memory leak in `Python < 2.7.4 / Python3 < 3.2.3`
+- Pylint goes bananas with E1123(unexpected-keyword-arg) and E1103(maybe-no-member)
+- For the uninitiated it seems like pure magic.
+
+Issues:
+
+- Dictionary key overrides dictionary methods:
+
+  ```
+  d = AttrDict()
+  d.update({'items':["a", "b"]})
+  d.items() # TypeError: 'list' object is not callable
+  ```
+
+**arguments**:
+are same as `dict()`, a dictionary or kwargs are both acceptable.
+
+**return**:
+an object provides with dictionary item access with attribute.
 
 ## dictutil.depth_iter
 

--- a/dictutil/__init__.py
+++ b/dictutil/__init__.py
@@ -1,15 +1,21 @@
 from .dictutil import (
+    attrdict,
     breadth_iter,
     depth_iter,
     make_getter,
     make_setter,
     make_getter_str,
+
+    AttrDict,
 )
 
 __all__ = [
+    "attrdict",
     "breadth_iter",
     "depth_iter",
     "make_getter",
     "make_setter",
     "make_getter_str",
+
+    "AttrDict",
 ]

--- a/dictutil/dictutil.py
+++ b/dictutil/dictutil.py
@@ -189,7 +189,7 @@ def _attrdict(d, ref):
     if id(d) in ref:
         return ref[id(d)]
 
-    # id is memory address
+    # id() is the memory address of an object, thus it is unique.
     ad = AttrDict(d)
     ref[id(d)] = ad
 

--- a/dictutil/dictutil.py
+++ b/dictutil/dictutil.py
@@ -165,14 +165,12 @@ class AttrDict(dict):
 
 
 def attrdict(*args, **kwargs):
+    """
+    Make a dict-like object whose keys can also be accessed with attribute.
+    You can use an AttrDict instance just like using a dict instance.
+    """
 
-    # try not to create a new dictionary. let referencing to itself works
-    if len(args) == 1 and isinstance(args[0], dict):
-        d = args[0]
-        d.update(kwargs)
-    else:
-        d = dict(*args, **kwargs)
-
+    d = dict(*args, **kwargs)
     ref = {}
 
     return _attrdict(d, ref)

--- a/dictutil/dictutil.py
+++ b/dictutil/dictutil.py
@@ -127,6 +127,78 @@ def make_setter(key_path, value=None, incr=False):
     return _set_dict
 
 
+class AttrDict(dict):
+
+    '''
+    a = AttrDict({1:2}) # {1:2}
+    a = AttrDict(x=3)   # {"x":3}
+    a.x                 # 3
+    a['x']              # 3
+
+    Some pros:
+
+    - It actually works!
+    - No dictionary class methods are shadowed (e.g. .keys() work just fine)
+    - Attributes and items are always in sync
+    - Trying to access non-existent key as an attribute correctly raises AttributeError instead of KeyError
+
+    Cons:
+
+    - Methods like .keys() will not work just fine if they get overwritten by incoming data
+    - Causes a memory leak in Python < 2.7.4 / Python3 < 3.2.3
+    - Pylint goes bananas with E1123(unexpected-keyword-arg) and E1103(maybe-no-member)
+    - For the uninitiated it seems like pure magic.
+
+    Issues:
+
+    - Dictionary key overrides dictionary methods:
+
+      d = AttrDict()
+      d.update({'items':["a", "b"]})
+      d.items() # TypeError: 'list' object is not callable
+
+    '''
+
+    def __init__(self, *args, **kwargs):
+        super(AttrDict, self).__init__(*args, **kwargs)
+        self.__dict__ = self
+
+
+def attrdict(*args, **kwargs):
+
+    # try not to create a new dictionary. let referencing to itself works
+    if len(args) == 1 and isinstance(args[0], dict):
+        d = args[0]
+        d.update(kwargs)
+    else:
+        d = dict(*args, **kwargs)
+
+    ref = {}
+
+    return _attrdict(d, ref)
+
+
+def _attrdict(d, ref):
+
+    if not isinstance(d, dict):
+        return d
+
+    if isinstance(d, AttrDict):
+        return d
+
+    if id(d) in ref:
+        return ref[id(d)]
+
+    # id is memory address
+    ad = AttrDict(d)
+    ref[id(d)] = ad
+
+    for k in d.keys():
+        ad[k] = _attrdict(d[k], ref)
+
+    return ad
+
+
 def _get_zero_value_of(val):
 
     if type(val) in types.StringTypes:

--- a/dictutil/test/test_dictutil.py
+++ b/dictutil/test/test_dictutil.py
@@ -521,3 +521,75 @@ class TestSetter(unittest.TestCase):
                                  rst=repr(rst),
                              )
                              )
+
+
+class TestAttrDict(unittest.TestCase):
+
+    def test_attrdict(self):
+
+        cases = (
+                ([],
+                 {},
+                 {}
+                 ),
+
+                ([],
+                 {'a': 2},
+                 {'a': 2}
+                 ),
+
+                ([{'x': 2}],
+                 {'a': 4},
+                 {'x': 2, 'a': 4},
+                 ),
+        )
+
+        for args, kwargs, expected in cases:
+            rst = dictutil.attrdict(*args, **kwargs)
+            self.assertEqual(expected, rst,
+                             'input: {a} {kw} {e}, rst: {rst}'.format(
+                                 a=args, kw=kwargs, e=expected, rst=rst))
+
+            for k in rst:
+                self.assertEqual(rst[k], getattr(rst, k))
+
+    def test_dict_method(self):
+
+        ad = dictutil.attrdict(a=1, b=2)
+
+        self.assertEqual(['a', 'b'], ad.keys())
+        self.assertEqual([1, 2], ad.values())
+        self.assertEqual([('a', 1), ('b', 2)], ad.items())
+
+    def test_recursive(self):
+
+        ad = dictutil.attrdict(
+            x=1, y={'a': 3, 'b': dict(c=4), 'd': dictutil.attrdict(z=5)})
+
+        self.assertEqual(1, ad.x)
+        self.assertEqual({'a': 3, 'b': {'c': 4}, 'd': {'z': 5}}, ad.y)
+        self.assertEqual(3, ad.y.a)
+        self.assertEqual(4, ad.y.b.c)
+        self.assertEqual(5, ad.y.d.z)
+
+    def test_attr_overriding(self):
+
+        ad = dictutil.attrdict(items=1)
+
+        with self.assertRaises(TypeError):
+            ad.items()
+
+    def test_ref_to_same_item(self):
+
+        x = {'a': 1}
+        ad = dictutil.attrdict(u=x, v=x)
+
+        self.assertTrue(ad.u is ad.v)
+
+        x['x'] = x
+        ad = dictutil.attrdict(x)
+
+        self.assertTrue(isinstance(ad, dictutil.AttrDict))
+        self.assertTrue(isinstance(ad.x, dictutil.AttrDict))
+        self.assertTrue(ad.x is ad)
+        self.assertTrue(ad.x.x is ad)

--- a/dictutil/test/test_dictutil.py
+++ b/dictutil/test/test_dictutil.py
@@ -591,5 +591,8 @@ class TestAttrDict(unittest.TestCase):
 
         self.assertTrue(isinstance(ad, dictutil.AttrDict))
         self.assertTrue(isinstance(ad.x, dictutil.AttrDict))
-        self.assertTrue(ad.x is ad)
-        self.assertTrue(ad.x.x is ad)
+        self.assertTrue(ad.x is not ad, 'attrdict does create a new dict')
+        self.assertTrue(
+            ad.x.x is ad.x, 'circular references work for all dict items.')
+        self.assertTrue(ad.x.x.x is ad.x.x,
+                        'circular references work for all dict items.(2)')


### PR DESCRIPTION
```
a = dictutil.attrdict(x=3, y={'z':4})
a['x']  # 3
a.x     # 3
a.y     # {'z':4}
a.y.z   # 4
```

Pros:

- It actually works!
- No dictionary class methods are shadowed (e.g. .keys() work just fine)
- Attributes and items are always in sync
- Trying to access non-existent key as an attribute correctly raises AttributeError instead of KeyError

Cons:

- Methods like .keys() will not work just fine if they get overwritten by incoming data
- Causes a memory leak in `Python < 2.7.4 / Python3 < 3.2.3`
- Pylint goes bananas with E1123(unexpected-keyword-arg) and E1103(maybe-no-member)
- For the uninitiated it seems like pure magic.

Issues:

- Dictionary key overrides dictionary methods:

  ```
  d = AttrDict()
  d.update({'items':["a", "b"]})
  d.items() # TypeError: 'list' object is not callable
  ```
