### PR TITLE
add logutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,22 +30,18 @@ library of our devops platform.
 
 #   Description
 
-There are several native modules like `utfjson`,
-along with several external modules like `jobq`, which are imported with
-`script/git-subrepo`(`git-subrepo` is also maintained by itself).
-
 ##  Module List
 
 There is a `README.md` for each module.
 
 | name                           | description                                                                           |
 | :--                            | :--                                                                                   |
-| script/git-subrepo             | A shell script maintaining sub module                                                 |
 | [cachepool](cachepool)         | Reusable object cache in process                                                      |
 | [daemonize](daemonize)         | Start, stop or restart a daemon process                                               |
 | [dictutil](dictutil)           | Dictionary helper utility                                                             |
 | [humannum](humannum)           | Convert number to human readable number string                                        |
 | [jobq](jobq)                   | Process serial of input elements with several functions concurrently and sequentially |
+| [logutil](logutil)             | Unitility functions to create logger or make log message                              |
 | [mysqlconnpool](mysqlconnpool) | Mysql connection pool with MySQLdb in python                                          |
 | [net](net)                     | Network utility                                                                       |
 | [portlock](portlock)           | cross process lock                                                                    |
@@ -94,23 +90,6 @@ Run one of following to test a all, a module, a TestCase or a function.
 ./script/t.sh zkutil.test_zkutil.TestZKUtil
 ./script/t.sh zkutil.test_zkutil.TestZKUtil.test_lock_data
 ```
-
-##  Update sub repo
-
->   You do not need to read this chapter if you are not a maintainer.
-
-First update sub repo config file `.gitsubrepo`
-and run `git-subrepo`.
-
-`git-subrepo` will fetch new changes from all sub repos and merge them into
-current branch `mater`:
-
-```
-./script/git-subrepo/git-subrepo
-```
-
-`git-subrepo` is a tool in shell script.
-It merges sub git repo into the parent git working dir with `git-submerge`.
 
 #   Author
 

--- a/logutil/README.md
+++ b/logutil/README.md
@@ -1,0 +1,437 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+#   Table of Content
+
+- [Name](#name)
+- [Status](#status)
+- [Description](#description)
+- [Class](#class)
+  - [logutil.FixedWatchedFileHandler](#logutilfixedwatchedfilehandler)
+- [Methods](#methods)
+  - [logutil.add_std_handler](#logutiladd_std_handler)
+  - [logutil.deprecate](#logutildeprecate)
+  - [logutil.get_datefmt](#logutilget_datefmt)
+  - [logutil.get_fmt](#logutilget_fmt)
+  - [logutil.get_root_log_fn](#logutilget_root_log_fn)
+  - [logutil.make_file_handler](#logutilmake_file_handler)
+  - [logutil.make_formatter](#logutilmake_formatter)
+  - [logutil.make_logger](#logutilmake_logger)
+  - [logutil.stack_format](#logutilstack_format)
+  - [logutil.stack_list](#logutilstack_list)
+  - [logutil.stack_str](#logutilstack_str)
+- [Author](#author)
+- [Copyright and License](#copyright-and-license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+#   Name
+
+logutil
+
+#   Status
+
+This library is considered production ready.
+
+#   Synopsis
+
+```python
+# make a file logger in one line
+logger = logutil.make_logger('/tmp', level='INFO', fmt='%(message)s',
+                             datefmt="%H:%M:%S")
+logger.info('foo')
+
+logger.stack_str(fmt="{fn}:{ln} in {func}\n  {statement}", sep="\n")
+# runpy.py:174 in _run_module_as_main
+#   "__main__", fname, loader, pkg_name)
+# runpy.py:72 in _run_code
+#   exec code in run_globals
+# ...
+# test_logutil.py:82 in test_deprecate
+#   logutil.deprecate()
+#   'foo', fmt='{fn}:{ln} in {func}\n  {statement}', sep='\n')
+```
+
+#   Description
+
+A collection of log utilities for logging.
+
+#   Class
+
+##  logutil.FixedWatchedFileHandler
+
+**syntax**:
+`logutil.FixedWatchedFileHandler(*args, **kwargs)`
+
+Fix an issue with the original `logging.handlers.WatchedFileHandler` in python2:
+
+Sometimes it raises an OSError when reading the log file stat after checking
+existence of the log file.
+Because the log file would be removed just after existence check and before
+reading log file stat.
+
+It has the same `__init__` arguments with
+`logging.handlers.WatchedFileHandler`.
+
+#   Methods
+
+##  logutil.add_std_handler
+
+**syntax**:
+`logutil.add_std_handler(logger, stream=None, fmt=None, datefmt=None)`
+
+It adds a `stdout` or `stderr` steam handler to the `logger`.
+
+**arguments**:
+
+-   `logger`:
+    is an instance of `logging.Logger` to add handler to.
+
+-   `stream`:
+    specifies the stream, it could be:
+    -   `sys.stdout` or a string `stdout`.
+    -   `sys.stderr` or a string `stderr`.
+
+-   `fmt`:
+    is the log message format.
+    It can be an alias name(like `default`) that can be used in
+    `logutil.get_fmt()`.
+    By default it is `default`: `[%(asctime)s,%(process)d-%(thread)d,%(filename)s,%(lineno)d,%(levelname)s] %(message)s`.
+
+-   `datefmt`:
+    is the format for date.
+    It can be an alias name(like `time`) that can be used in
+    `logutil.get_datefmt()`.
+    By default it is `None`.
+
+**return**:
+the `logger` argument.
+
+##  logutil.deprecate
+
+**syntax**:
+`logutil.deprecate(mes=None, fmt=None, sep=None)`
+
+Print a `deprecate` message with root logger, at warning level.
+The printed message includes:
+
+-   User defined message `mes`,
+-   And calling stack of where this warning occurs.
+    `<frame-n>` is where `logutil.deprecate` is called.
+
+```
+<mes> Deprecated: <frame-1> --- <frame-2> --- ... --- <frame-n>
+```
+
+The default frame format is `{fn}:{ln} in {func} {statement}`.
+It can be changed with argument `fmt`.
+Frame separator by default is ` --- `, and can be changed with argument `sep`.
+
+For example, the following statement:
+
+```
+def foo():
+    logutil.deprecate('should not be here.',
+                      fmt="{fn}:{ln} in {func}\n  {statement}",
+                      sep="\n"
+                      )
+```
+
+Would produce a message:
+
+```
+Deprecated: should not be here.
+runpy.py:174 in _run_module_as_main
+  "__main__", fname, loader, pkg_name)
+runpy.py:72 in _run_code
+  exec code in run_globals
+...
+test_logutil.py:82 in test_deprecate
+  logutil.deprecate()
+  'foo', fmt='{fn}:{ln} in {func}\n  {statement}', sep='\n')
+```
+
+**arguments**:
+
+-   `mes`:
+    is description of the `deprecated` statement.
+    It could be `None`.
+
+-   `fmt`:
+    is call stack frame format.
+    By default it is `{fn}:{ln} in {func} {statement}`.
+
+-   `sep`:
+    is the separator string between each frame.
+    By default it is ` --- `.
+    Thus all frames are printed in a single line.
+
+**return**:
+Nothing.
+
+##  logutil.get_datefmt
+
+**syntax**:
+`logutil.get_datefmt(datefmt)`
+
+It translates a predefined datefmt alias to actual datefmt.
+Predefined alias includes:
+
+```
+{
+    'default':  None,       # use the system default datefmt
+    'time':     '%H:%M:%S',
+}
+```
+
+**arguments**:
+
+-   `datefmt`:
+    is the alias name.
+    If no predefined alias name is found, it returns the passed in value of
+    `datefmt`.
+
+**return**:
+translated `datefmt` or the original value of argument `datefmt`.
+
+##  logutil.get_fmt
+
+**syntax**:
+`logutil.get_fmt(fmt)`
+
+It translate a predefined fmt alias to actual fmt.
+Predefined alias includes:
+
+```
+{
+    'default':    '[%(asctime)s,%(process)d-%(thread)d,%(filename)s,%(lineno)d,%(levelname)s] %(message)s',
+    'time_level': "[%(asctime)s,%(levelname)s] %(message)s",
+    'message':    '%(message)s',
+}
+```
+
+**arguments**:
+
+-   `fmt`:
+    is the alias name.
+    If no predefined alias name is found, it returns the passed in value of
+    `fmt`.
+
+**return**:
+translated `fmt` or the original value of argument `fmt`.
+
+##  logutil.get_root_log_fn
+
+**syntax**:
+`logutil.get_root_log_fn()`
+
+The log file name suffix is `.out`.
+
+-   `pyfn.out`: if program is started with `python pyfn.py`.
+-   `__instant_command__.out`: if instance python command is called:
+    `python -c "import logutil; print logutil.get_root_log_fn()`.
+-   `__stdin__.out`: if python statement is passed in as stdin:
+    `echo "from pykit import logutil; print logutil.get_root_log_fn()" | python`.
+
+**return**:
+log file name.
+
+##  logutil.make_file_handler
+
+**syntax**:
+`logutil.make_file_handler(base_dir, log_fn, fmt=None, datefmt=None)`
+
+It creates a rolling log file handler.
+
+A rolling file can be removed at any time.
+This handler checks file status everytime write log to it.
+If file is changed(removed or moved), this handler automatically creates a new
+log file.
+
+**arguments**:
+
+-   `base_dir`:
+    specifies the dir of log file.
+
+-   `log_fn`:
+    specifies the log file name.
+
+-   `fmt`:
+    specifies log format.
+    It can be an alias that can be used in `logutil.get_fmt()`, or `None` to
+    used the `default` log format.
+
+-   `datefmt`:
+    specifies log date format.
+    It can be an alias that can be used in `logutil.get_datefmt()`, or `None` to
+    used the `default` date format.
+
+**return**:
+an instance of `logging.handlers.WatchedFileHandler`.
+
+##  logutil.make_formatter
+
+**syntax**:
+`logutil.make_formatter(fmt=None, datefmt=None)`
+
+It creates an `logging.Formatter` instance, with specified `fmt` and `datefmt`.
+
+**arguments**:
+
+-   `fmt`:
+    specifies log format.
+    It can be an alias that can be used in `logutil.get_fmt()`, or `None` to
+    used the `default` log format.
+
+-   `datefmt`:
+    specifies log date format.
+    It can be an alias that can be used in `logutil.get_datefmt()`, or `None` to
+    used the `default` date format.
+
+**return**:
+an `logging.Formatter` instance.
+
+##  logutil.make_logger
+
+**syntax**:
+`logutil.make_logger(base_dir, log_name=None, log_fn=None,
+                     level=logging.DEBUG, fmt=None,
+                     datefmt=None)`
+
+It creates a logger with a rolling file hander and specified formats.
+
+**arguments**:
+
+-   `base_dir`:
+    specifies the dir of log file.
+
+-   `log_name`:
+    is the name of the logger to create.
+    `None` means the root logger.
+
+-   `log_fn`:
+    specifies the log file name.
+    If it is `None`, use `logutil.get_root_log_fn` to make a log file name.
+
+-   `level`:
+    specifies log level.
+    It could be int value such as `logging.DEBUG` or string such as `DEBUG`.
+
+-   `fmt`:
+    specifies log format.
+    It can be an alias that can be used in `logutil.get_fmt()`, or `None` to
+    used the `default` log format.
+
+-   `datefmt`:
+    specifies log date format.
+    It can be an alias that can be used in `logutil.get_datefmt()`, or `None` to
+    used the `default` date format.
+
+**return**:
+a `logging.Logger` instance.
+
+##  logutil.stack_format
+
+**syntax**:
+`logutil.stack_format(stacks, fmt=None, sep=None)`
+
+It formats stack made from `logutil.stack_list`.
+
+With `fmt="{fn}:{ln} in {func}\n  {statement}"`
+and `sep="\n"`, a formatted stack would be:
+
+```
+runpy.py:174 in _run_module_as_main
+  "__main__", fname, loader, pkg_name)
+runpy.py:72 in _run_code
+  exec code in run_globals
+...
+test_logutil.py:82 in test_deprecate
+  logutil.deprecate()
+  'foo', fmt='{fn}:{ln} in {func}\n  {statement}', sep='\n')
+```
+
+**arguments**:
+
+-   `stacks`:
+    is stack from `logutil.stack_list`.
+
+    ```
+    [
+        {
+            'fn': ...
+            'ln': ...
+            'func': ...
+            'statement': ...
+        }
+        ...
+    ]
+    ```
+
+-   `fmt`:
+    specifies the template to format a stack frame.
+    By default it is: `{fn}:{ln} in {func} {statement}`.
+
+-   `sep`:
+    specifies the separator string between each stack frame.
+    By default it is ` --- `.
+    Thus all frames are in the same line.
+
+**return**:
+a string repesenting a calling stack.
+
+##  logutil.stack_list
+
+**syntax**:
+`logutil.stack_list(offset=0)`
+
+It returns the calling stack from where it is called.
+
+**arguments**:
+
+-   `offset`:
+    remove the lowest `offset` frames.
+
+**return**:
+list of:
+
+```
+{
+    'fn': ...
+    'ln': ...
+    'func': ...
+    'statement': ...
+}
+```
+
+
+##  logutil.stack_str
+
+**syntax**:
+`logutil.stack_str(offset=0, fmt=None, sep=None)`
+
+It creates a string representing calling stack from where this function is
+called.
+
+**arguments**:
+
+-   `offset=0`:
+    remove the lowest `offset` frames.
+    Because usually one does not need the frame of the `logutil.stack_str`
+    line.
+
+-   `fmt`: is same as `logutil.stack_format`.
+-   `sep`: is same as `logutil.stack_format`.
+
+**return**:
+a string repesenting a calling stack.
+
+
+#   Author
+
+Zhang Yanpo (张炎泼) <drdr.xp@gmail.com>
+
+#   Copyright and License
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Zhang Yanpo (张炎泼) <drdr.xp@gmail.com>

--- a/logutil/README.md
+++ b/logutil/README.md
@@ -109,17 +109,17 @@ the `logger` argument.
 ##  logutil.deprecate
 
 **syntax**:
-`logutil.deprecate(mes=None, fmt=None, sep=None)`
+`logutil.deprecate(msg=None, fmt=None, sep=None)`
 
 Print a `deprecate` message with root logger, at warning level.
 The printed message includes:
 
--   User defined message `mes`,
+-   User defined message `msg`,
 -   And calling stack of where this warning occurs.
     `<frame-n>` is where `logutil.deprecate` is called.
 
 ```
-<mes> Deprecated: <frame-1> --- <frame-2> --- ... --- <frame-n>
+<msg> Deprecated: <frame-1> --- <frame-2> --- ... --- <frame-n>
 ```
 
 The default frame format is `{fn}:{ln} in {func} {statement}`.
@@ -152,7 +152,7 @@ test_logutil.py:82 in test_deprecate
 
 **arguments**:
 
--   `mes`:
+-   `msg`:
     is description of the `deprecated` statement.
     It could be `None`.
 

--- a/logutil/__init__.py
+++ b/logutil/__init__.py
@@ -1,0 +1,27 @@
+from .logutil import (
+    add_std_handler,
+    deprecate,
+    get_datefmt,
+    get_fmt,
+    get_root_log_fn,
+    make_file_handler,
+    make_formatter,
+    make_logger,
+    stack_format,
+    stack_list,
+    stack_str,
+)
+
+__all__ = [
+    'add_std_handler',  # used
+    'deprecate',
+    'get_datefmt',
+    'get_fmt',  # used
+    'get_root_log_fn',  # used
+    'make_file_handler',
+    'make_formatter',
+    'make_logger',
+    'stack_format',
+    'stack_list',
+    'stack_str',  # used
+]

--- a/logutil/logutil.py
+++ b/logutil/logutil.py
@@ -1,5 +1,4 @@
 import errno
-import fcntl
 import logging
 import logging.handlers
 import os
@@ -75,8 +74,8 @@ class FixedWatchedFileHandler(logging.FileHandler):
         try:
             # stat the file by path, checking for existence
             sres = os.stat(self.baseFilename)
-        except OSError as err:
-            if err.errno == errno.ENOENT:
+        except OSError as e:
+            if e.errno == errno.ENOENT:
                 sres = None
             else:
                 raise
@@ -89,7 +88,7 @@ class FixedWatchedFileHandler(logging.FileHandler):
             #     Thus we keep on trying this close/open/stat loop until no OSError
             #     raises.
 
-            for ii in range(1024):
+            for ii in range(16):
                 try:
                     if self.stream is not None:
                         # we have an open file handle, clean it up
@@ -103,7 +102,7 @@ class FixedWatchedFileHandler(logging.FileHandler):
                         self._statstream()
                         break
                 except OSError as e:
-                    if err.errno == errno.ENOENT:
+                    if e.errno == errno.ENOENT:
                         continue
                     else:
                         raise
@@ -233,12 +232,12 @@ def stack_str(offset=0, fmt=None, sep=None):
     return stack_format(stack_list(offset), fmt=fmt, sep=sep)
 
 
-def deprecate(mes=None, fmt=None, sep=None):
+def deprecate(msg=None, fmt=None, sep=None):
 
     d = 'Deprecated:'
 
-    if mes is not None:
-        d += ' ' + str(mes)
+    if msg is not None:
+        d += ' ' + str(msg)
 
     logger.warn(d + (sep or default_stack_sep)
                 + stack_str(offset=1, fmt=fmt, sep=sep))

--- a/logutil/logutil.py
+++ b/logutil/logutil.py
@@ -83,10 +83,10 @@ class FixedWatchedFileHandler(logging.FileHandler):
         if not sres or sres[ST_DEV] != self.dev or sres[ST_INO] != self.ino:
 
             # Fixed by xp 2017 Apr 03:
-            #     os.fstat still gets OSError(errno=2), although it operates directly on fd instead of path.
-            #     The same for stream.flush().
-            #     Thus we keep on trying this close/open/stat loop until no OSError
-            #     raises.
+            #     os.fstat still gets OSError(errno=2), although it operates
+            #     directly on fd instead of path.  The same for stream.flush().
+            #     Thus we keep on trying this close/open/stat loop until no
+            #     OSError raises.
 
             for ii in range(16):
                 try:
@@ -149,7 +149,6 @@ def make_file_handler(base_dir, log_fn, fmt=None, datefmt=None):
     file_path = os.path.join(base_dir, log_fn)
 
     handler = FixedWatchedFileHandler(file_path)
-    # handler = logging.handlers.WatchedFileHandler(file_path)
     handler.setFormatter(make_formatter(fmt=fmt, datefmt=datefmt))
 
     return handler

--- a/logutil/logutil.py
+++ b/logutil/logutil.py
@@ -1,0 +1,244 @@
+import errno
+import fcntl
+import logging
+import logging.handlers
+import os
+import sys
+import traceback
+from stat import ST_DEV
+from stat import ST_INO
+
+import __main__
+
+logger = logging.getLogger(__name__)
+
+log_formats = {
+    'default': '[%(asctime)s,%(process)d-%(thread)d,%(filename)s,%(lineno)d,%(levelname)s] %(message)s',
+    'time_level': "[%(asctime)s,%(levelname)s] %(message)s",
+    'message': '%(message)s',
+}
+
+date_formats = {
+    # by default do not specify
+    'default': None,
+    'time': '%H:%M:%S',
+}
+
+log_suffix = 'out'
+
+default_stack_sep = ' --- '
+
+
+class FixedWatchedFileHandler(logging.FileHandler):
+    """
+    A handler for logging to a file, which watches the file
+    to see if it has changed while in use. This can happen because of
+    usage of programs such as newsyslog and logrotate which perform
+    log file rotation. This handler, intended for use under Unix,
+    watches the file to see if it has changed since the last emit.
+    (A file has changed if its device or inode have changed.)
+    If it has changed, the old file stream is closed, and the file
+    opened to get a new stream.
+
+    This handler is not appropriate for use under Windows, because
+    under Windows open files cannot be moved or renamed - logging
+    opens the files with exclusive locks - and so there is no need
+    for such a handler. Furthermore, ST_INO is not supported under
+    Windows; stat always returns zero for this value.
+
+    This handler is based on a suggestion and patch by Chad J.
+    Schroeder.
+    """
+
+    def __init__(self, filename, mode='a', encoding=None, delay=0):
+        logging.FileHandler.__init__(self, filename, mode, encoding, delay)
+        self.dev, self.ino = -1, -1
+        self._statstream()
+
+    def _statstream(self):
+        if self.stream:
+            sres = os.fstat(self.stream.fileno())
+            self.dev, self.ino = sres[ST_DEV], sres[ST_INO]
+
+    def emit(self, record):
+        """
+        Emit a record.
+
+        First check if the underlying file has changed, and if it
+        has, close the old stream and reopen the file to get the
+        current stream.
+        """
+        # Reduce the chance of race conditions by stat'ing by path only
+        # once and then fstat'ing our new fd if we opened a new log stream.
+        # See issue #14632: Thanks to John Mulligan for the problem report
+        # and patch.
+        try:
+            # stat the file by path, checking for existence
+            sres = os.stat(self.baseFilename)
+        except OSError as err:
+            if err.errno == errno.ENOENT:
+                sres = None
+            else:
+                raise
+        # compare file system stat with that of our stream file handle
+        if not sres or sres[ST_DEV] != self.dev or sres[ST_INO] != self.ino:
+
+            # Fixed by xp 2017 Apr 03:
+            #     os.fstat still gets OSError(errno=2), although it operates directly on fd instead of path.
+            #     The same for stream.flush().
+            #     Thus we keep on trying this close/open/stat loop until no OSError
+            #     raises.
+
+            for ii in range(1024):
+                try:
+                    if self.stream is not None:
+                        # we have an open file handle, clean it up
+                        self.stream.flush()
+                        self.stream.close()
+                        # See Issue #21742: _open () might fail.
+                        self.stream = None
+                        # open a new file handle and get new stat info from
+                        # that fd
+                        self.stream = self._open()
+                        self._statstream()
+                        break
+                except OSError as e:
+                    if err.errno == errno.ENOENT:
+                        continue
+                    else:
+                        raise
+        logging.FileHandler.emit(self, record)
+
+
+def get_root_log_fn():
+
+    if hasattr(__main__, '__file__'):
+        name = __main__.__file__
+        name = os.path.basename(name)
+        if name == '<stdin>':
+            name = '__stdin__'
+        return name.rsplit('.', 1)[0] + '.' + log_suffix
+    else:
+        return '__instant_command__.' + log_suffix
+
+
+def make_logger(base_dir, log_name=None, log_fn=None,
+                level=logging.DEBUG, fmt=None,
+                datefmt=None):
+
+    # if log_name is None, get the root logger
+    logger = logging.getLogger(log_name)
+    logger.setLevel(level)
+
+    # do not add 2 handlers to one logger by default
+    if len(logger.handlers) == 0:
+
+        if log_fn is None:
+            if log_name is None:
+                log_fn = get_root_log_fn()
+            else:
+                log_fn = log_name + '.' + log_suffix
+
+        logger.addHandler(make_file_handler(base_dir, log_fn,
+                                            fmt=fmt, datefmt=datefmt))
+
+    return logger
+
+
+def make_file_handler(base_dir, log_fn, fmt=None, datefmt=None):
+
+    file_path = os.path.join(base_dir, log_fn)
+
+    handler = FixedWatchedFileHandler(file_path)
+    # handler = logging.handlers.WatchedFileHandler(file_path)
+    handler.setFormatter(make_formatter(fmt=fmt, datefmt=datefmt))
+
+    return handler
+
+
+def add_std_handler(logger, stream=None, fmt=None, datefmt=None):
+
+    stream = stream or sys.stdout
+
+    if stream == 'stdout':
+        stream = sys.stdout
+
+    elif stream == 'stderr':
+        stream = sys.stderr
+
+    stdhandler = logging.StreamHandler(stream)
+    stdhandler.setFormatter(make_formatter(fmt=fmt, datefmt=datefmt))
+
+    logger.addHandler(stdhandler)
+
+    return logger
+
+
+def make_formatter(fmt=None, datefmt=None):
+
+    fmt = get_fmt(fmt)
+    datefmt = get_datefmt(datefmt)
+
+    return logging.Formatter(fmt=fmt, datefmt=datefmt)
+
+
+def get_fmt(fmt):
+
+    if fmt is None:
+        fmt = 'default'
+
+    return log_formats.get(fmt, fmt)
+
+
+def get_datefmt(datefmt):
+
+    if datefmt is None:
+        return datefmt
+
+    return date_formats.get(datefmt, datefmt)
+
+
+def stack_list(offset=0):
+    offset += 1  # count this function as 1
+
+    # list of ( filename, line-nr, in-what-function, statement )
+    x = traceback.extract_stack()
+    return x[: -offset]
+
+
+def stack_format(stacks, fmt=None, sep=None):
+
+    if fmt is None:
+        fmt = "{fn}:{ln} in {func} {statement}"
+
+    if sep is None:
+        sep = default_stack_sep
+
+    dict_stacks = []
+    for st in stacks:
+        o = {
+            'fn': os.path.basename(st[0]),
+            'ln': st[1],
+            'func': st[2],
+            'statement': st[3],
+        }
+        dict_stacks.append(o)
+
+    return sep.join([fmt.format(**xx)
+                     for xx in dict_stacks])
+
+
+def stack_str(offset=0, fmt=None, sep=None):
+    offset += 1  # count this function as 1
+    return stack_format(stack_list(offset), fmt=fmt, sep=sep)
+
+
+def deprecate(mes=None, fmt=None, sep=None):
+
+    d = 'Deprecated:'
+
+    if mes is not None:
+        d += ' ' + str(mes)
+
+    logger.warn(d + (sep or default_stack_sep)
+                + stack_str(offset=1, fmt=fmt, sep=sep))

--- a/logutil/test/foo.py
+++ b/logutil/test/foo.py
@@ -1,0 +1,3 @@
+from pykit import logutil
+
+print logutil.get_root_log_fn()

--- a/logutil/test/stdlog.py
+++ b/logutil/test/stdlog.py
@@ -1,0 +1,8 @@
+from pykit import logutil
+
+logger = logutil.make_logger('/tmp', log_fn='stdlog', level='INFO',
+                             fmt='message')
+
+
+logutil.add_std_handler(logger, 'stdout', fmt='message')
+logger.info('stdlog')

--- a/logutil/test/test_logutil.py
+++ b/logutil/test/test_logutil.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import re
 import subprocess
 import threading
 import unittest
@@ -109,12 +108,12 @@ class TestLogutil(unittest.TestCase):
 
         cont = read_file('/tmp/t.out')
 
-        t = re.findall('^Deprecated: foo', cont)
-        self.assertTrue(len(t) == 1)
-
-        t = re.findall(
-            'test_logutil.py::\d+ in test_deprecate\n  logutil.deprecate', cont)
-        self.assertEqual(1, len(t))
+        self.assertRegexpMatches(
+            cont,
+            '^Deprecated: foo')
+        self.assertRegexpMatches(
+            cont,
+            'test_logutil.py::\d+ in test_deprecate\n  logutil.deprecate')
 
     def test_stack_list(self):
 
@@ -124,7 +123,7 @@ class TestLogutil(unittest.TestCase):
         self.assertEqual('test_logutil.py', os.path.basename(last[0]))
         self.assertTrue(isinstance(last[1], int))
         self.assertEqual('test_stack_list', last[2])
-        self.assertTrue(re.match('^ *stack = ', last[3]))
+        self.assertRegexpMatches(last[3], '^ *stack = ')
 
     def test_format_stack(self):
 
@@ -143,8 +142,9 @@ class TestLogutil(unittest.TestCase):
     def test_stack_str(self):
 
         rst = logutil.stack_str(fmt='{fn}-{ln}-{func}-{statement}', sep=' ')
-        self.assertEqual(
-            1, len(re.findall(' test_logutil.py-\d+-test_stack_str- *rst = ', rst)))
+        self.assertRegexpMatches(
+            rst,
+            ' test_logutil.py-\d+-test_stack_str- *rst = ')
 
     def test_get_datefmt(self):
 
@@ -190,7 +190,7 @@ class TestLogutil(unittest.TestCase):
 
         cont = read_file('/tmp/tt').strip()
 
-        self.assertTrue(re.match('\d\d\d\d\d\d-info', cont))
+        self.assertRegexpMatches(cont, '\d\d\d\d\d\d-info')
 
     def test_make_formatter(self):
         # how to test logging.Formatter?

--- a/logutil/test/test_logutil.py
+++ b/logutil/test/test_logutil.py
@@ -1,0 +1,208 @@
+import logging
+import os
+import re
+import subprocess
+import threading
+import unittest
+
+from pykit import logutil
+
+logger = logging.getLogger(__name__)
+
+
+def subproc(script, cwd=None):
+
+    subproc = subprocess.Popen(['sh'],
+                               close_fds=True,
+                               cwd=cwd,
+                               stdin=subprocess.PIPE,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+
+    out, err = subproc.communicate(script)
+
+    subproc.wait()
+
+    if subproc.returncode != 0:
+        print out
+        print err
+
+    return (subproc.returncode, out, err)
+
+
+def read_file(fn):
+    try:
+        with open(fn, 'r') as f:
+            cont = f.read()
+            return cont
+    except EnvironmentError:
+        return None
+
+
+def rm_file(fn):
+    try:
+        os.unlink(fn)
+    except EnvironmentError:
+        pass
+
+
+class TestFileHandler(unittest.TestCase):
+
+    def test_concurrent_write_and_remove(self):
+
+        l = logutil.make_logger('/tmp', log_name='rolling', log_fn='rolling.out',
+                                level=logging.DEBUG, fmt='message')
+
+        n = 10240
+        sess = {'running': True}
+
+        def _remove():
+            while sess['running']:
+                rm_file('/tmp/rolling.out')
+
+        th = threading.Thread(target=_remove)
+        th.daemon = True
+        th.start()
+
+        for ii in range(n):
+            l.debug('123')
+
+        sess['running'] = False
+        th.join()
+
+
+class TestLogutil(unittest.TestCase):
+
+    def setUp(self):
+
+        rm_file('/tmp/t.out')
+
+        # root logger
+        logutil.make_logger('/tmp', log_fn='t.out',
+                            level=logging.DEBUG, fmt='message')
+
+    def test_get_root_log_fn(self):
+
+        # instant
+
+        code, out, err = subproc(
+            'python -c "from pykit import logutil; print logutil.get_root_log_fn()"')
+        self.assertEqual(0, code)
+        self.assertEqual('__instant_command__.out', out.strip())
+
+        code, out, err = subproc(
+            'echo "from pykit import logutil; print logutil.get_root_log_fn()" | python')
+        self.assertEqual(0, code)
+        self.assertEqual('__stdin__.out', out.strip())
+
+        # load by file
+
+        code, out, err = subproc(
+            'python foo.py', cwd=os.path.dirname(__file__))
+        self.assertEqual(0, code)
+        self.assertEqual('foo.out', out.strip())
+
+    def test_deprecate(self):
+
+        fmt = '{fn}::{ln} in {func}\n  {statement}'
+        logutil.deprecate('foo', fmt=fmt, sep='\n')
+
+        cont = read_file('/tmp/t.out')
+
+        t = re.findall('^Deprecated: foo', cont)
+        self.assertTrue(len(t) == 1)
+
+        t = re.findall(
+            'test_logutil.py::\d+ in test_deprecate\n  logutil.deprecate', cont)
+        self.assertEqual(1, len(t))
+
+    def test_stack_list(self):
+
+        stack = logutil.stack_list()
+        last = stack[-1]
+
+        self.assertEqual('test_logutil.py', os.path.basename(last[0]))
+        self.assertTrue(isinstance(last[1], int))
+        self.assertEqual('test_stack_list', last[2])
+        self.assertTrue(re.match('^ *stack = ', last[3]))
+
+    def test_format_stack(self):
+
+        cases = (
+            ([('0', 1, 2, 3)], '0-1-2-3'),
+            ([('0', 1, 2, 3),
+              ('a', 'b', 'c', 'd')], '0-1-2-3\na-b-c-d'),
+        )
+
+        for inp, expected in cases:
+
+            rst = logutil.stack_format(
+                inp, fmt='{fn}-{ln}-{func}-{statement}', sep='\n')
+            self.assertEqual(expected, rst)
+
+    def test_stack_str(self):
+
+        rst = logutil.stack_str(fmt='{fn}-{ln}-{func}-{statement}', sep=' ')
+        self.assertEqual(
+            1, len(re.findall(' test_logutil.py-\d+-test_stack_str- *rst = ', rst)))
+
+    def test_get_datefmt(self):
+
+        cases = (
+                (None,      None),
+                ('default', None),
+                ('time',    '%H:%M:%S'),
+                ('%H%M%S',  '%H%M%S'),
+        )
+
+        for inp, expected in cases:
+            rst = logutil.get_datefmt(inp)
+
+            self.assertEqual(expected, rst)
+
+    def test_get_fmt(self):
+
+        cases = (
+                (None,
+                 '[%(asctime)s,%(process)d-%(thread)d,%(filename)s,%(lineno)d,%(levelname)s] %(message)s'),
+                ('default',
+                 '[%(asctime)s,%(process)d-%(thread)d,%(filename)s,%(lineno)d,%(levelname)s] %(message)s'),
+                ('time_level',  "[%(asctime)s,%(levelname)s] %(message)s"),
+                ('message',     '%(message)s'),
+                ('%(message)s', '%(message)s'),
+        )
+
+        for inp, expected in cases:
+            rst = logutil.get_fmt(inp)
+            self.assertEqual(expected, rst)
+
+    def test_make_logger(self):
+
+        rm_file('/tmp/tt')
+
+        l = logutil.make_logger('/tmp', log_name='m', log_fn='tt',
+                                level='INFO', fmt='%(asctime)s-%(message)s',
+                                datefmt='%H%M%S'
+                                )
+
+        l.debug('debug')
+        l.info('info')
+
+        cont = read_file('/tmp/tt').strip()
+
+        self.assertTrue(re.match('\d\d\d\d\d\d-info', cont))
+
+    def test_make_formatter(self):
+        # how to test logging.Formatter?
+        pass
+
+    def test_make_file_handler(self):
+        # how to test logging.handlers.*?
+        pass
+
+    def test_add_std_handler(self):
+
+        code, out, err = subproc(
+            'python stdlog.py', cwd=os.path.dirname(__file__))
+        self.assertEqual(0, code)
+        self.assertEqual('stdlog', out.strip())


### PR DESCRIPTION
```
# make a file logger in one line
logger = logutil.make_logger('/tmp', level='INFO', fmt='%(message)s',
                             datefmt="%H:%M:%S")
logger.info('foo')

logger.stack_str(fmt="{fn}:{ln} in {func}\n  {statement}", sep="\n")
# runpy.py:174 in _run_module_as_main
#   "__main__", fname, loader, pkg_name)
# runpy.py:72 in _run_code
#   exec code in run_globals
# ...
# test_logutil.py:82 in test_deprecate
#   logutil.deprecate()
#   'foo', fmt='{fn}:{ln} in {func}\n  {statement}', sep='\n')
```

function list:
```
logutil.add_std_handler
logutil.deprecate
logutil.get_datefmt
logutil.get_fmt
logutil.get_root_log_fn
logutil.make_file_handler
logutil.make_formatter
logutil.make_logger
logutil.stack_format
logutil.stack_list
logutil.stack_str
```