### PR TITLE
ututil.dd() for unittest debug logging

### DIFF
--- a/logutil/logutil.py
+++ b/logutil/logutil.py
@@ -15,6 +15,9 @@ log_formats = {
     'default': '[%(asctime)s,%(process)d-%(thread)d,%(filename)s,%(lineno)d,%(levelname)s] %(message)s',
     'time_level': "[%(asctime)s,%(levelname)s] %(message)s",
     'message': '%(message)s',
+
+    # more info: but it is too long.
+    # 'full': '[%(asctime)s,%(process)d-%(thread)d,%(name)s, %(filename)s,%(lineno)d,%(funcName)s %(levelname)s] %(message)s',
 }
 
 date_formats = {

--- a/strutil/test/test_strutil.py
+++ b/strutil/test/test_strutil.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python2
 # coding: utf-8
 
-import inspect
 import logging
 import unittest
 
 from pykit import strutil
+from pykit import ututil
+
+dd = ututil.dd
 
 
 class TestStrutil(unittest.TestCase):
@@ -85,9 +87,6 @@ class TestStrutil(unittest.TestCase):
 
     def test_format_line(self):
 
-        logger = logging.getLogger(
-            __name__ + '.' + self.__class__.__name__ + '.' + inspect.stack()[0][3])
-
         cases = (
                 (([], '', ''),
                  '',
@@ -130,8 +129,8 @@ class TestStrutil(unittest.TestCase):
 
             rst = strutil.format_line(*_in)
 
-            logger.debug("in: " + str(_in))
-            logger.debug("rst:\n" + rst)
+            dd("_in: " + str(_in))
+            dd("rst:\n" + rst)
 
             self.assertEqual(_out, rst,
                              ('input: {_in}, output: {_out}, expected: {rst},'
@@ -224,7 +223,3 @@ class TestColoredString(unittest.TestCase):
         print strutil.normal('normal'),
         print strutil.optimal('optimal'),
         print
-
-
-# logging.basicConfig( stream=sys.stderr )
-# logging.getLogger( __name__ + '.TestStrutil.test_format_line' ).setLevel( logging.DEBUG )

--- a/ututil.py
+++ b/ututil.py
@@ -19,7 +19,7 @@ class ContextFilter(logging.Filter):
 
     To fix the issue that when test case function use dd() instead of
     logger.debug(), logging alwasy print context info of dd(), but not the
-    calling function test_xxx.
+    caller test_xxx.
     """
 
     def filter(self, record):
@@ -82,7 +82,7 @@ def dd(*msg):
 
     _init()
 
-    l = case_logger()
+    l = get_case_logger()
     l.debug(s)
 
     if get_ut_verbosity() < 2:
@@ -106,7 +106,7 @@ def get_ut_verbosity():
     return self.verbosity
 
 
-def case_logger():
+def get_case_logger():
     """
     Get a case specific logger.
     The logger name is: `<module>.<class>.<function>`,

--- a/ututil.py
+++ b/ututil.py
@@ -8,7 +8,7 @@ import os
 import unittest
 
 _glb = {
-    'inited': False,
+    'unittest_logger': None,
 }
 
 
@@ -48,14 +48,15 @@ class ContextFilter(logging.Filter):
 
 def _init():
 
-    if _glb['inited']:
+    if _glb['unittest_logger'] is not None:
         return
 
     # test_logutil might require this module and logutil is still under test!
     try:
         from pykit import logutil
-        logutil.make_logger(
+        logger = logutil.make_logger(
             '/tmp',
+            log_name='unittest',
             level='DEBUG',
             fmt=('[%(asctime)s'
                  ' %(_fn)s:%(_ln)d'
@@ -63,11 +64,12 @@ def _init():
                  ' %(message)s'
                  )
         )
+        logger.addFilter(ContextFilter())
+
+        _glb['unittest_logger'] = logger
 
     except Exception as e:
         print repr(e) + ' while init root logger'
-
-    _glb['inited'] = True
 
 
 def dd(*msg):
@@ -82,8 +84,9 @@ def dd(*msg):
 
     _init()
 
-    l = get_case_logger()
-    l.debug(s)
+    l = _glb['unittest_logger']
+    if l:
+        l.debug(s)
 
     if get_ut_verbosity() < 2:
         return


### PR DESCRIPTION
-      add ututil.dd(), for debug logging in cases
-      use ututil.dd() for debug logging in cases

To display debug info for unittest(with `-v`):

```
./script/t.sh -v [module]
```

Add debug logging in unittest:

```
def test_xx(self):
    dd('display me if verbosity >= 2')
```