### PR TITLE
修正portlock bug和其他小调整

### DIFF
--- a/cachepool/test/test_cachepool.py
+++ b/cachepool/test/test_cachepool.py
@@ -1,10 +1,11 @@
 import unittest
 
+from pykit import ututil
 from pykit.cachepool import CachePool
 from pykit.cachepool import CachePoolGeneratorError
 from pykit.cachepool import make_wrapper
 
-_DEBUG_ = True
+dd = ututil.dd
 
 
 # Exception that is used for test.
@@ -367,11 +368,3 @@ def reuse_for_acceptable_errors(errtype, errval, _traceback):
 
 def reuse_decider_error(errtype, errval, _traceback):
     raise ErrorInReuse()
-
-
-def dd(*msgs):
-    if not _DEBUG_:
-        return
-
-    for msg in msgs:
-        print str(msg)

--- a/humannum/test/test_humannum.py
+++ b/humannum/test/test_humannum.py
@@ -39,14 +39,14 @@ class TestHumannum(unittest.TestCase):
 
             rst = humannum.humannum(_in)
 
-            mes = 'humanize: in: {_in} expect: {_out}, rst: {rst}; {_mes}'.format(
+            msg = 'humanize: in: {_in} expect: {_out}, rst: {rst}; {_mes}'.format(
                 _in=repr(_in),
                 _out=repr(_out),
                 rst=rst,
                 _mes=_mes
             )
 
-            self.assertEqual(_out, rst, mes)
+            self.assertEqual(_out, rst, msg)
 
     def test_parse_number(self):
 
@@ -78,23 +78,23 @@ class TestHumannum(unittest.TestCase):
 
             rst = humannum.parsenum(_in)
 
-            mes = 'parse: in: {_in} expect: {_out}, rst: {rst}; {_mes}'.format(
+            msg = 'parse: in: {_in} expect: {_out}, rst: {rst}; {_mes}'.format(
                 _in=repr(_in),
                 _out=repr(_out),
                 rst=rst,
                 _mes=_mes
             )
 
-            self.assertEqual(_out, rst, mes)
+            self.assertEqual(_out, rst, msg)
 
             self.assertEqual(int(_out), humannum.parseint(_in),
-                             mes + '; parseint')
+                             msg + '; parseint')
 
             self.assertEqual(int(_out), humannum.parseint(_in + 'B'),
-                             mes + '; parseint and suffix "B"')
+                             msg + '; parseint and suffix "B"')
 
             self.assertEqual(int(_out), humannum.parseint(_in + 'i'),
-                             mes + '; parseint and suffix "i"')
+                             msg + '; parseint and suffix "i"')
 
     def test_specified_unit(self):
 
@@ -107,14 +107,14 @@ class TestHumannum(unittest.TestCase):
 
             rst = humannum.humannum(_in[0], **_in[1])
 
-            mes = 'in: {_in} expect: {_out}, rst: {rst}; {_mes}'.format(
+            msg = 'in: {_in} expect: {_out}, rst: {rst}; {_mes}'.format(
                 _in=repr(_in),
                 _out=repr(_out),
                 rst=rst,
                 _mes=_mes
             )
 
-            self.assertEqual(_out, rst, mes)
+            self.assertEqual(_out, rst, msg)
 
     def test_non_primitive(self):
 
@@ -128,14 +128,14 @@ class TestHumannum(unittest.TestCase):
 
             rst = humannum.humannum(_in)
 
-            mes = 'in: {_in} expect: {_out}, rst: {rst}; {_mes}'.format(
+            msg = 'in: {_in} expect: {_out}, rst: {rst}; {_mes}'.format(
                 _in=repr(_in),
                 _out=repr(_out),
                 rst=rst,
                 _mes=_mes
             )
 
-            self.assertEqual(_out, rst, mes)
+            self.assertEqual(_out, rst, msg)
             self.assertTrue(_in is not rst, 'result must not be input')
 
     def test_limit_keys(self):
@@ -155,12 +155,12 @@ class TestHumannum(unittest.TestCase):
 
             rst = humannum.humannum(_in[0], **_in[1])
 
-            mes = 'in: {_in} expect: {_out}, rst: {rst}; {_mes}'.format(
+            msg = 'in: {_in} expect: {_out}, rst: {rst}; {_mes}'.format(
                 _in=repr(_in),
                 _out=repr(_out),
                 rst=rst,
                 _mes=_mes
             )
 
-            self.assertEqual(_out, rst, mes)
+            self.assertEqual(_out, rst, msg)
             self.assertTrue(_in is not rst, 'result must not be input')

--- a/humannum/test/test_humannum.py
+++ b/humannum/test/test_humannum.py
@@ -35,15 +35,15 @@ class TestHumannum(unittest.TestCase):
                 (True,                    True,    ''),
         )
 
-        for _in, _out, _mes in cases:
+        for _in, _out, _msg in cases:
 
             rst = humannum.humannum(_in)
 
-            msg = 'humanize: in: {_in} expect: {_out}, rst: {rst}; {_mes}'.format(
+            msg = 'humanize: in: {_in} expect: {_out}, rst: {rst}; {_msg}'.format(
                 _in=repr(_in),
                 _out=repr(_out),
                 rst=rst,
-                _mes=_mes
+                _msg=_msg
             )
 
             self.assertEqual(_out, rst, msg)
@@ -74,15 +74,15 @@ class TestHumannum(unittest.TestCase):
                 ('1.00M',     1048576,       ''),
         )
 
-        for _in, _out, _mes in cases:
+        for _in, _out, _msg in cases:
 
             rst = humannum.parsenum(_in)
 
-            msg = 'parse: in: {_in} expect: {_out}, rst: {rst}; {_mes}'.format(
+            msg = 'parse: in: {_in} expect: {_out}, rst: {rst}; {_msg}'.format(
                 _in=repr(_in),
                 _out=repr(_out),
                 rst=rst,
-                _mes=_mes
+                _msg=_msg
             )
 
             self.assertEqual(_out, rst, msg)
@@ -103,15 +103,15 @@ class TestHumannum(unittest.TestCase):
                 ((1024 ** 2, {'unit': 1024**3}),   '0.001G',  ''),
         )
 
-        for _in, _out, _mes in cases:
+        for _in, _out, _msg in cases:
 
             rst = humannum.humannum(_in[0], **_in[1])
 
-            msg = 'in: {_in} expect: {_out}, rst: {rst}; {_mes}'.format(
+            msg = 'in: {_in} expect: {_out}, rst: {rst}; {_msg}'.format(
                 _in=repr(_in),
                 _out=repr(_out),
                 rst=rst,
-                _mes=_mes
+                _msg=_msg
             )
 
             self.assertEqual(_out, rst, msg)
@@ -124,15 +124,15 @@ class TestHumannum(unittest.TestCase):
                 ([{'a': 'xp'},  1024432],   [{'a': 'xp'}, '1000.4K'], ''),
         )
 
-        for _in, _out, _mes in cases:
+        for _in, _out, _msg in cases:
 
             rst = humannum.humannum(_in)
 
-            msg = 'in: {_in} expect: {_out}, rst: {rst}; {_mes}'.format(
+            msg = 'in: {_in} expect: {_out}, rst: {rst}; {_msg}'.format(
                 _in=repr(_in),
                 _out=repr(_out),
                 rst=rst,
-                _mes=_mes
+                _msg=_msg
             )
 
             self.assertEqual(_out, rst, msg)
@@ -151,15 +151,15 @@ class TestHumannum(unittest.TestCase):
                  ),
         )
 
-        for _in, _out, _mes in cases:
+        for _in, _out, _msg in cases:
 
             rst = humannum.humannum(_in[0], **_in[1])
 
-            msg = 'in: {_in} expect: {_out}, rst: {rst}; {_mes}'.format(
+            msg = 'in: {_in} expect: {_out}, rst: {rst}; {_msg}'.format(
                 _in=repr(_in),
                 _out=repr(_out),
                 rst=rst,
-                _mes=_mes
+                _msg=_msg
             )
 
             self.assertEqual(_out, rst, msg)

--- a/jobq/test/test_jobq.py
+++ b/jobq/test/test_jobq.py
@@ -1,8 +1,9 @@
+import logging
 import threading
 import time
 import unittest
 
-import jobq
+from pykit import jobq
 
 
 def add1(args):
@@ -233,6 +234,11 @@ class TestJobQ(unittest.TestCase):
 
     def test_exception(self):
 
+        # Add a handler, or python complains "no handler assigned
+        # to...."
+        jl = logging.getLogger('pykit.jobq')
+        jl.addHandler(logging.NullHandler())
+
         def err_on_even(args):
             if args % 2 == 0:
                 raise Exception('even number')
@@ -245,6 +251,9 @@ class TestJobQ(unittest.TestCase):
         rst = []
         jobq.run(range(10), [err_on_even, collect])
         self.assertEqual(list(range(1, 10, 2)), rst)
+
+        # remove NullHandler
+        jl.handlers = []
 
     def test_sequential(self):
 
@@ -323,10 +332,6 @@ class TestDefaultTimeout(unittest.TestCase):
         # value
 
         def _sleep_1(args):
-            time.sleep(1)
+            time.sleep(0.02)
 
         jobq.run(range(1), [_sleep_1])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/portlock/test/test_portlock.py
+++ b/portlock/test/test_portlock.py
@@ -3,11 +3,9 @@ import time
 import unittest
 
 from pykit import portlock
+from pykit import ututil
 
-
-def dd(*msg):
-    pass
-    # print msg
+dd = ututil.dd
 
 
 class TestPortlock(unittest.TestCase):

--- a/portlock/test/test_portlock.py
+++ b/portlock/test/test_portlock.py
@@ -60,9 +60,10 @@ class TestPortlock(unittest.TestCase):
                 dd('{0}-{1} start'.format(ident, ii))
 
                 self.assertEqual(
-                    0, sess['n'], 'n is 0 just after lock is acquired')
+                    0, sess['n'], 'n is 0 just after lock is acquired, 1-lock-for-1')
 
                 sess['n'] += 1
+                time.sleep(0.001)
                 self.assertEqual(
                     1, sess['n'], "no more than 2 thread holding lock")
                 sess['n'] -= 1
@@ -90,9 +91,10 @@ class TestPortlock(unittest.TestCase):
                 l.acquire()
 
                 self.assertEqual(
-                    0, sess['n'], 'n is 0 just after lock is acquired')
+                    0, sess['n'], 'n is 0 just after lock is acquired, 1-lock-for-all')
 
                 sess['n'] += 1
+                time.sleep(0.001)
                 self.assertEqual(
                     1,  sess['n'], "no more than 2 thread holding lock")
                 sess['n'] -= 1

--- a/profiling/snippet/uncollectible.py
+++ b/profiling/snippet/uncollectible.py
@@ -35,8 +35,8 @@ The simpliest is an object that refers to itself and with a __del__ defined.
 '''
 
 
-def dd(*mes):
-    for m in mes:
+def dd(*msg):
+    for m in msg:
         print(m, end='')
     print()
 

--- a/script/t.sh
+++ b/script/t.sh
@@ -9,14 +9,30 @@
 #     script/t.sh [-v] zkutil.test_zkutil.TestZKUtil.test_lock_data
 
 flag=
-while getopts v opname; do
-    case $opname in
-        v)
-            flag="-v"
-            shift
-            ;;
-    esac
+ut_debug=
+verbosity=
+while [ "$#" -gt 0 ]; do
+
+    # -v or -vv
+    if [ "${1:0:2}" = "-v" ]; then
+        flag='-v'
+        verbosity="v$verbosity"
+
+        # -vv
+        more=${1:2}
+
+        if [ "$more" = 'v' ]; then
+            verbosity="v$verbosity"
+        fi
+        shift
+    else
+        break
+    fi
 done
+
+if [ "$verbosity" = 'vv' ]; then
+    ut_debug=1
+fi
 
 pkg="${1%/}"
 
@@ -31,10 +47,13 @@ pkg="${pkg%.}"
 # Add env variable PYTHONPATH to let all modules in sub folder can find the
 # root package.
 
+# UT_DEBUG controls if dd() should output debug log to stdout.
+# see ututil.py
+
 if python -c 'import '$pkg 2>/dev/null; then
     # it is a module
-    PYTHONPATH="$(pwd)" python2 -m unittest discover -c $flag --failfast -s "$pkg"
+    PYTHONPATH="$(pwd)" UT_DEBUG=$ut_debug python2 -m unittest discover -c $flag --failfast -s "$pkg"
 else
     # it is a class or function: pykit.zkutil.test.test_zkutil.TestXXX
-    PYTHONPATH="$(pwd)" python2 -m unittest -c $flag --failfast "$pkg"
+    PYTHONPATH="$(pwd)" UT_DEBUG=$ut_debug python2 -m unittest -c $flag --failfast "$pkg"
 fi

--- a/ututil.py
+++ b/ututil.py
@@ -11,6 +11,8 @@ _glb = {
     'unittest_logger': None,
 }
 
+debug_to_stdout = os.environ.get('UT_DEBUG') == '1'
+
 
 class ContextFilter(logging.Filter):
 
@@ -88,7 +90,7 @@ def dd(*msg):
     if l:
         l.debug(s)
 
-    if get_ut_verbosity() < 2:
+    if not debug_to_stdout:
         return
 
     print s

--- a/zkutil/zkutil.py
+++ b/zkutil/zkutil.py
@@ -2,7 +2,7 @@
 import os
 import types
 
-from .. import net
+from pykit import net
 
 # We assumes that ip does not change during process running.
 # Display intra ip if presents, or display pub ip.


### PR DESCRIPTION
## rename mes -> msg
## refine test_jobq.py.
- add NullHandler to jobq to supress no-handler-complain.
- remove if-main block
- fix import
- smaller sleep time

## test_cachepool use ututil.dd()
## test_portlock.py use ututil.dd()
## script/t.sh controls debug logging.
```
./script/t.sh
> ..
> ----------------------------------------------------------------------
> Ran 2 tests in 0.001s

./script/t.sh -v
> test_lock_data (pykit.zkutil.test.test_zkutil.TestZKutil) ... ok
> test_parse_lock_data (pykit.zkutil.test.test_zkutil.TestZKutil) ... ok
>
> ----------------------------------------------------------------------
> Ran 2 tests in 0.001s

./script/t.sh -vv
> # let dd() to print debug log to stdout.
```

## fix portlock bug: 1lock for all threads
## fix zkutil: import from pykit, instead of relative package