### PR TITLE
add timeutil.to_ts() to convert sec, msec, usec, nsec to second

### DIFF
--- a/timeutil/README.md
+++ b/timeutil/README.md
@@ -9,8 +9,8 @@
 - [Methods](#methods)
   - [timeutil.parse](#timeutilparse)
   - [timeutil.format](#timeutilformat)
-  - [timeutil.format_ts](#timeutilformatts)
-  - [timeutil.utc_datetime_to_ts](#timeutilutcdatetime_to_ts)
+  - [timeutil.format_ts](#timeutilformat_ts)
+  - [timeutil.utc_datetime_to_ts](#timeutilutc_datetime_to_ts)
   - [timeutil.ts_to_datetime](#timeutilts_to_datetime)
   - [timeutil.ts](#timeutilts)
   - [timeutil.ms](#timeutilms)
@@ -19,7 +19,7 @@
   - [timeutil.ms_to_ts](#timeutilms_to_ts)
   - [timeutil.us_to_ts](#timeutilus_to_ts)
   - [timeutil.ns_to_ts](#timeutilns_to_ts)
-
+  - [timeutil.to_ts](#timeutilto_ts)
 - [Author](#author)
 - [Copyright and License](#copyright-and-license)
 
@@ -243,6 +243,23 @@ convert timestamp from nanosecond to second
 
 **return**:
     timestamp in second
+
+##  timeutil.to_ts
+
+**syntax**:
+`timeutil.to_ts(val)`
+
+Convert timestamp in second, ms, us or ns to second.
+If `val` is not a valid timestamp, it raises `ValueError`.
+
+**arguments**:
+
+-   `val`: timestamp in int, long or float.
+    It can be a timestamp in second, millisecond(10e-3), microsecond(10e-6) or
+    nanosecond(10e-9).
+
+**return**:
+timestamp in second
 
 # Author
 

--- a/timeutil/README.md
+++ b/timeutil/README.md
@@ -19,7 +19,7 @@
   - [timeutil.ms_to_ts](#timeutilms_to_ts)
   - [timeutil.us_to_ts](#timeutilus_to_ts)
   - [timeutil.ns_to_ts](#timeutilns_to_ts)
-  - [timeutil.to_ts](#timeutilto_ts)
+  - [timeutil.to_sec](#timeutilto_sec)
 - [Author](#author)
 - [Copyright and License](#copyright-and-license)
 
@@ -244,17 +244,17 @@ convert timestamp from nanosecond to second
 **return**:
     timestamp in second
 
-##  timeutil.to_ts
+##  timeutil.to_sec
 
 **syntax**:
-`timeutil.to_ts(val)`
+`timeutil.to_sec(val)`
 
 Convert timestamp in second, ms, us or ns to second.
 If `val` is not a valid timestamp, it raises `ValueError`.
 
 **arguments**:
 
--   `val`: timestamp in int, long or float.
+-   `val`: timestamp in int, long, float or string.
     It can be a timestamp in second, millisecond(10e-3), microsecond(10e-6) or
     nanosecond(10e-9).
 

--- a/timeutil/__init__.py
+++ b/timeutil/__init__.py
@@ -12,7 +12,7 @@ from .timeutil import (
     ms_to_ts,
     us_to_ts,
     ns_to_ts,
-    to_ts,
+    to_sec,
 )
 
 __all__ = [
@@ -29,5 +29,5 @@ __all__ = [
     'ms_to_ts',
     'us_to_ts',
     'ns_to_ts',
-    'to_ts',
+    'to_sec',
 ]

--- a/timeutil/__init__.py
+++ b/timeutil/__init__.py
@@ -12,6 +12,7 @@ from .timeutil import (
     ms_to_ts,
     us_to_ts,
     ns_to_ts,
+    to_ts,
 )
 
 __all__ = [
@@ -28,4 +29,5 @@ __all__ = [
     'ms_to_ts',
     'us_to_ts',
     'ns_to_ts',
+    'to_ts',
 ]

--- a/timeutil/test/test_timeutil.py
+++ b/timeutil/test/test_timeutil.py
@@ -131,7 +131,11 @@ class TestTimeutil(unittest.TestCase):
 
         for inp in cases:
             dd(inp, ts)
-            self.assertEqual(ts, timeutil.to_ts(inp),
+
+            self.assertEqual(ts, timeutil.to_sec(inp),
+                             'convert {inp} to second'.format(inp=repr(inp)))
+
+            self.assertEqual(ts, timeutil.to_sec(str(inp)),
                              'convert {inp} to second'.format(inp=repr(inp)))
 
     def test_to_ts_invalid_input(self):
@@ -151,4 +155,4 @@ class TestTimeutil(unittest.TestCase):
         for inp in cases:
 
             with self.assertRaises(ValueError):
-                timeutil.to_ts(inp)
+                timeutil.to_sec(inp)

--- a/timeutil/test/test_timeutil.py
+++ b/timeutil/test/test_timeutil.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python2.6
 # coding: utf-8
 
+import datetime
 import time
 import unittest
 
 from pykit import timeutil
+from pykit import ututil
+
+dd = ututil.dd
 
 test_case = {
     'ts': {
@@ -104,3 +108,47 @@ class TestTimeutil(unittest.TestCase):
         self.assertEqual(ts, timeutil.ms_to_ts(ms))
         self.assertEqual(ts, timeutil.us_to_ts(us))
         self.assertEqual(ts, timeutil.ns_to_ts(ns))
+
+    def test_to_ts(self):
+
+        ts = timeutil.ts()
+
+        cases = (
+            ts,
+            ts + 0.1,
+            ts * 1000,
+            ts * 1000 + 1,
+            ts * 1000 + 0.1,
+
+            ts * 1000 * 1000,
+            ts * 1000 * 1000 + 1,
+            ts * 1000 * 1000 + 0.1,
+
+            ts * 1000 * 1000 * 1000,
+            ts * 1000 * 1000 * 1000 + 1,
+            ts * 1000 * 1000 * 1000 + 0.1,
+        )
+
+        for inp in cases:
+            dd(inp, ts)
+            self.assertEqual(ts, timeutil.to_ts(inp),
+                             'convert {inp} to second'.format(inp=repr(inp)))
+
+    def test_to_ts_invalid_input(self):
+
+        cases = (
+            'a',
+            '1',
+            '1.1',
+            -123456789,
+            {},
+            [],
+            (),
+            True,
+            datetime.datetime.now(),
+        )
+
+        for inp in cases:
+
+            with self.assertRaises(ValueError):
+                timeutil.to_ts(inp)

--- a/timeutil/timeutil.py
+++ b/timeutil/timeutil.py
@@ -69,3 +69,27 @@ def us_to_ts(us):
 
 def ns_to_ts(ns):
     return ns / (1000 ** 3)
+
+
+def to_ts(v):
+    """
+    convert millisecond, microsecond or nanosecond to second
+    """
+
+    if (type(v) not in (type(1), type(1L), type(0.1))
+            or v < 0):
+        raise ValueError('invalid time to convert to second: {v}'.format(v=v))
+
+    l = len(str(int(v)))
+
+    if l == 10:
+        return int(v)
+    elif l == 13:
+        return int(v / 1000)
+    elif l == 16:
+        return int(v / (1000**2))
+    elif l == 19:
+        return int(v / (1000**3))
+    else:
+        raise ValueError(
+            'invalid time length, not 10, 13, 16 or 19: {v}'.format(v=v))

--- a/timeutil/timeutil.py
+++ b/timeutil/timeutil.py
@@ -4,6 +4,7 @@
 import calendar
 import datetime
 import time
+import types
 
 formats = {
     'default': '%a, %d %b %Y %H:%M:%S UTC',
@@ -71,12 +72,17 @@ def ns_to_ts(ns):
     return ns / (1000 ** 3)
 
 
-def to_ts(v):
+def to_sec(v):
+
     """
-    convert millisecond, microsecond or nanosecond to second
+    Convert millisecond, microsecond or nanosecond to second.
+
+    ms_to_ts, us_to_ts, ns_to_ts are then deprecated.
     """
 
-    if (type(v) not in (type(1), type(1L), type(0.1))
+    v = float(str(v))
+
+    if (type(v) != types.FloatType
             or v < 0):
         raise ValueError('invalid time to convert to second: {v}'.format(v=v))
 


### PR DESCRIPTION
```
def to_ts(v):
    """
    convert millisecond, microsecond or nanosecond to second
    """

    if (type(v) not in (type(1), type(1L), type(0.1))
            or v < 0):
        raise ValueError('invalid time to convert to second: {v}'.format(v=v))

    l = len(str(int(v)))

    if l == 10:
        return int(v)
    elif l == 13:
        return int(v / 1000)
    elif l == 16:
        return int(v / (1000**2))
    elif l == 19:
        return int(v / (1000**3))
    else:
        raise ValueError(
            'invalid time length, not 10, 13, 16 or 19: {v}'.format(v=v))

```