### PR TITLE
http: add profiling support, collect time spend on each phase.

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -223,7 +223,7 @@ Whether response body is chunked encoding or not.
 ##  http.Client
 
 **syntax**:
-`http.Client(host, port, timeout=60)`
+`http.Client(host, port, timeout=60, stopwatch_kwargs=None)`
 
 HTTP client class
 
@@ -240,6 +240,20 @@ HTTP client class
     The value argument can be a nonnegative float expressing seconds, or `None`.
     if `None`, it is equivalent to `socket.setblocking(1)`.
     if `0.0`, it is equivalent to `socket.setblocking(0)`.
+
+-   `stopwatch_kwargs`:
+    is an dictionary used as keyword arguments when initializing stopwatch instance.
+
+    ```
+    class StopWatch(object):
+        def __init__(self,
+                     strict_assert=True,
+                     export_tracing_func=None,
+                     export_aggregated_timers_func=None,
+                     max_tracing_spans_for_path=1000,
+                     min_tracing_milliseconds=3,
+                     time_func=None):
+    ```
 
 #   Methods
 

--- a/http/README.md
+++ b/http/README.md
@@ -30,7 +30,7 @@
   - [http.Client.request](#httpclientrequest)
   - [http.Client.send_body](#httpclientsend_body)
   - [http.Client.read_body](#httpclientread_body)
-  - [http.Client.get_profile_str](#httpclientget_profile_str)
+  - [http.Client.get_trace_str](#httpclientget_trace_str)
 - [Author](#author)
 - [Copyright and License](#copyright-and-license)
 
@@ -223,7 +223,7 @@ Whether response body is chunked encoding or not.
 ##  http.Client
 
 **syntax**:
-`http.Client(host, port, timeout=60, profiling=True)`
+`http.Client(host, port, timeout=60)`
 
 HTTP client class
 
@@ -240,15 +240,6 @@ HTTP client class
     The value argument can be a nonnegative float expressing seconds, or `None`.
     if `None`, it is equivalent to `socket.setblocking(1)`.
     if `0.0`, it is equivalent to `socket.setblocking(0)`.
-
--   `profiling`:
-    whether to collect time spent on each phase.
-
-    By default it is `True`.
-
-    One could use `http.Client.get_profile_str()` to retreive profiling
-    information, it returns a string like:
-    `conn: 0.000450, send_header: 0.000110, recv_status: 0.000541, recv_header: 0.000027, recv_body: 0.000050`
 
 #   Methods
 
@@ -374,17 +365,17 @@ Read and return the response body.
 **return**:
 the response body.
 
-##  http.Client.get_profile_str
+##  http.Client.get_trace_str
 
 **syntax**:
-`http.Client.get_profile_str()`
+`http.Client.get_trace_str()`
 
 **return**:
 a string shows time spent on each phase of a request.
 The following fields would presents in it:
 
 ```
-conn: 0.000450, send_header: 0.000110, recv_status: 0.000541, recv_header: 0.000027, recv_body: 0.000050
+conn: 0.000001 -; send_header: 0.000000 -; recv_status: 0.000000 -; recv_header: 0.000000 -; recv_body: 0.000000 -; recv_body: 0.000000 -; exception: 0.000000 -; pykit.http.Client: 0.000002 Exception:ValueError
 ```
 
 The numbers are time in second.

--- a/http/README.md
+++ b/http/README.md
@@ -7,31 +7,34 @@
 - [Synopsis](#synopsis)
 - [Description](#description)
 - [Exceptions](#exceptions)
-    - [http.HttpError](#httphttperror)
-    - [http.LineTooLongError](#httplinetoolongerror)
-    - [http.ChunkedSizeError](#httpchunkedsizeerror)
-    - [http.NotConnectedError](#httpnotconnectederror)
-    - [http.ResponseNotReadyError](#httpresponsenotreadyerror)
-    - [http.HeadersError](#httpheaderserror)
-    - [http.BadStatusLineError](#httpbadstatuslineerror)
+  - [http.HttpError](#httphttperror)
+  - [http.LineTooLongError](#httplinetoolongerror)
+  - [http.ChunkedSizeError](#httpchunkedsizeerror)
+  - [http.NotConnectedError](#httpnotconnectederror)
+  - [http.ResponseNotReadyError](#httpresponsenotreadyerror)
+  - [http.HeadersError](#httpheaderserror)
+  - [http.BadStatusLineError](#httpbadstatuslineerror)
 - [Constants](#constants)
-    - [http.Client.status](#httpclientstatus)
-    - [http.Client.has_read](#httpclienthas_read)
-    - [http.Client.headers](#httpclientheaders)
-    - [http.Client.content_length](#httpclientcontent_length)
-    - [http.Client.chunked](#httpclientchunked)
+  - [http.Client.status](#httpclientstatus)
+  - [http.Client.has_read](#httpclienthas_read)
+  - [http.Client.headers](#httpclientheaders)
+  - [http.Client.content_length](#httpclientcontent_length)
+  - [http.Client.chunked](#httpclientchunked)
 - [Classes](#classes)
-    - [http.Client](#httpclient)
+  - [http.Client](#httpclient)
 - [Methods](#methods)
-    - [http.Client.send_request](#httpclientsend_request)
-    - [http.Client.read_status](#httpclientread_status)
-    - [http.Client.read_headers](#httpclientread_headers)
-    - [http.Client.read_response](#httpclientread_response)
-    - [http.Client.request](#httpclientrequest)
-    - [http.Client.send_body](#httpclientsend_body)
-    - [http.Client.read_body](#httpclientread_body)
+  - [http.Client.send_request](#httpclientsend_request)
+  - [http.Client.read_status](#httpclientread_status)
+  - [http.Client.read_headers](#httpclientread_headers)
+  - [http.Client.read_response](#httpclientread_response)
+  - [http.Client.request](#httpclientrequest)
+  - [http.Client.send_body](#httpclientsend_body)
+  - [http.Client.read_body](#httpclientread_body)
+  - [http.Client.get_profile_str](#httpclientget_profile_str)
 - [Author](#author)
 - [Copyright and License](#copyright-and-license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 #   Name
 
@@ -220,7 +223,7 @@ Whether response body is chunked encoding or not.
 ##  http.Client
 
 **syntax**:
-`http.Client(host, port, timeout=60)`
+`http.Client(host, port, timeout=60, profiling=True)`
 
 HTTP client class
 
@@ -238,6 +241,14 @@ HTTP client class
     if `None`, it is equivalent to `socket.setblocking(1)`.
     if `0.0`, it is equivalent to `socket.setblocking(0)`.
 
+-   `profiling`:
+    whether to collect time spent on each phase.
+
+    By default it is `True`.
+
+    One could use `http.Client.get_profile_str()` to retreive profiling
+    information, it returns a string like:
+    `conn: 0.000450, send_header: 0.000110, recv_status: 0.000541, recv_header: 0.000027, recv_body: 0.000050`
 
 #   Methods
 
@@ -362,6 +373,32 @@ Read and return the response body.
 
 **return**:
 the response body.
+
+##  http.Client.get_profile_str
+
+**syntax**:
+`http.Client.get_profile_str()`
+
+**return**:
+a string shows time spent on each phase of a request.
+The following fields would presents in it:
+
+```
+conn: 0.000450, send_header: 0.000110, recv_status: 0.000541, recv_header: 0.000027, recv_body: 0.000050
+```
+
+The numbers are time in second.
+
+It is possible there are less than these field, if request failed.
+
+It is also possible some of the above fields appear more than once.
+
+For example if a server responds a `100-Continue` status line and a `200-OK`
+status line, there would be two `recv_status` fields.
+
+If the caller calls `http.Client.read_body` more than one time, there would be
+more than one `recv_body` fields.
+
 
 #   Author
 

--- a/http/README.md
+++ b/http/README.md
@@ -389,7 +389,7 @@ conn: 0.000450, send_header: 0.000110, recv_status: 0.000541, recv_header: 0.000
 
 The numbers are time in second.
 
-It is possible there are less than these field, if request failed.
+There might be less fields in the result, if request failed.
 
 It is also possible some of the above fields appear more than once.
 

--- a/http/client.py
+++ b/http/client.py
@@ -173,13 +173,13 @@ class Client(object):
                 break
 
             # skip the header from the 100 response
-            while True:
+            with self.stopwatch.timer('recv_skip_header'):
 
-                with self.stopwatch.timer('recv_skip_header'):
+                while True:
+
                     skip = self._readline()
-
-                if skip.strip() == '':
-                    break
+                    if skip.strip() == '':
+                        break
 
         self.status = status
         return status

--- a/http/test/test_httpclient.py
+++ b/http/test/test_httpclient.py
@@ -272,6 +272,9 @@ class TestHttpClient(unittest.TestCase):
 
     def test_trace(self):
 
+        class FakeErrorDuringHTTP(Exception):
+            pass
+
         h = http.Client(HOST, PORT)
         h.request('/get_10k')
         h.read_body(1)
@@ -280,7 +283,7 @@ class TestHttpClient(unittest.TestCase):
         # emulate error
         try:
             with h.stopwatch.timer('exception'):
-                raise ValueError(3)
+                raise FakeErrorDuringHTTP(3)
         except Exception:
             pass
 
@@ -300,8 +303,13 @@ class TestHttpClient(unittest.TestCase):
             self.assertEqual(type(0.1), type(trace[i]['time']))
 
         names = [x['name'] for x in trace]
-        self.assertEqual(['conn', 'send_header', 'recv_status', 'recv_header',
-                          'recv_body', 'recv_body', 'exception',
+        self.assertEqual(['conn',
+                          'send_header',
+                          'recv_status',
+                          'recv_header',
+                          'recv_body',
+                          'recv_body',
+                          'exception',
                           'pykit.http.Client'],
                          names)
 
@@ -309,7 +317,8 @@ class TestHttpClient(unittest.TestCase):
 
     def test_trace_min_tracing_milliseconds(self):
 
-        h = http.Client(HOST, PORT, stopwatch_kwargs={'min_tracing_milliseconds':1000})
+        h = http.Client(HOST, PORT, stopwatch_kwargs={
+                        'min_tracing_milliseconds': 1000})
         h.request('/get_10k')
         h.read_body(None)
 

--- a/http/test/test_httpclient.py
+++ b/http/test/test_httpclient.py
@@ -277,6 +277,7 @@ class TestHttpClient(unittest.TestCase):
         h.read_body(1)
         h.read_body(None)
 
+        # emulate error
         try:
             with h.stopwatch.timer('exception'):
                 raise ValueError(3)

--- a/http/test/test_httpclient.py
+++ b/http/test/test_httpclient.py
@@ -270,6 +270,26 @@ class TestHttpClient(unittest.TestCase):
         gc.collect()
         self.assertListEqual([], gc.garbage)
 
+    def test_profiling(self):
+
+        h = http.Client(HOST, PORT)
+        h.request('/get_10k')
+        h.read_body(None)
+
+        ks = (
+            'conn',
+            'send_header',
+            'recv_status',
+            'recv_header',
+            'recv_body',
+        )
+
+        for i, k in enumerate(ks):
+            self.assertEqual(k, h.profile[i][0])
+            self.assertEqual(type(0.1), type(h.profile[i][1]))
+
+        dd(h.get_profile_str())
+
     def __init__(self, *args, **kwargs):
 
         super(TestHttpClient, self).__init__(*args, **kwargs)
@@ -279,6 +299,7 @@ class TestHttpClient(unittest.TestCase):
     def setUp(self):
 
         self.server_thread = threading.Thread(target=self._start_server)
+        self.server_thread.daemon = True
         self.server_thread.start()
         time.sleep(0.1)
 

--- a/http/test/test_httpclient.py
+++ b/http/test/test_httpclient.py
@@ -270,7 +270,7 @@ class TestHttpClient(unittest.TestCase):
         gc.collect()
         self.assertListEqual([], gc.garbage)
 
-    def test_profiling(self):
+    def test_trace(self):
 
         h = http.Client(HOST, PORT)
         h.request('/get_10k')
@@ -306,6 +306,20 @@ class TestHttpClient(unittest.TestCase):
                          names)
 
         dd('trace str:', h.get_trace_str())
+
+    def test_trace_min_tracing_milliseconds(self):
+
+        h = http.Client(HOST, PORT, stopwatch_kwargs={'min_tracing_milliseconds':1000})
+        h.request('/get_10k')
+        h.read_body(None)
+
+        # only steps cost time>1000 are traced. thus nothing should be traced
+        trace_str = h.get_trace_str()
+        dd('trace:', trace_str)
+
+        self.assertEqual('', trace_str)
+
+        self.assertEqual([], h.get_trace())
 
     def __init__(self, *args, **kwargs):
 


### PR DESCRIPTION
Example:
"conn: 0.000524, send_header: 0.000034, recv_status: 0.000346, recv_header: 0.000078, recv_body: 0.000104"