### PR TITLE
p3json load() always output str, no unicode anymore

### DIFF
--- a/p3json/decoder.py
+++ b/p3json/decoder.py
@@ -121,8 +121,9 @@ def py_scanstring(s, end, strict=True,
                 if 0xdc00 <= uni2 <= 0xdfff:
                     uni = 0x10000 + (((uni - 0xd800) << 10) | (uni2 - 0xdc00))
                     end += 6
-            # XXX for python2 json compatibility: in py3, chr is ok for unicode. in py2: unichr
-            char = unichr(uni)
+            # XXX for python2 json compatibility: output all string as utf-8,
+            # in order to ensure that result string is not unicode
+            char = unichr(uni).encode('utf-8')
         _append(char)
     return ''.join(chunks), end
 

--- a/p3json/test/test_pass1.py
+++ b/p3json/test/test_pass1.py
@@ -67,7 +67,8 @@ class TestPass1(object):
     def test_parse(self):
         # test in/out equivalence and parsing
         res = self.loads(JSON)
-        out = self.dumps(res)
+        # XXX for python2 json compatibility: use ensure_ascii=False to dumps encoded string.
+        out = self.dumps(res, ensure_ascii=False)
         self.assertEqual(res, self.loads(out))
 
 

--- a/p3json/test/test_scanstring.py
+++ b/p3json/test/test_scanstring.py
@@ -95,21 +95,22 @@ class TestScanstring(object):
         def assertScan(given, expect):
             self.assertEqual(scanstring(given, 1, None, True),
                              (expect, len(given)))
-            if not isinstance(given, unicode):
-                given = unicode(given)
-                self.assertEqual(scanstring(given, 1, None, True),
-                                 (expect, len(given)))
+            # XXX for python2 json compatibility: no unicode is allowed as input json-string
+            # if not isinstance(given, unicode):
+            #     given = unicode(given)
+            #     self.assertEqual(scanstring(given, 1, None, True),
+            #                      (expect, len(given)))
 
-        surrogates = unichr(0xd834) + unichr(0xdd20)
-        assertScan('"z\\ud834\\u0079x"', u'z\ud834yx')
-        assertScan('"z\\ud834\\udd20x"', u'z\U0001d120x')
-        assertScan('"z\\ud834\\ud834\\udd20x"', u'z\ud834\U0001d120x')
-        assertScan('"z\\ud834x"', u'z\ud834x')
-        assertScan(u'"z\\ud834\udd20x12345"', u'z%sx12345' % surrogates)
-        assertScan('"z\\udd20x"', u'z\udd20x')
-        assertScan(u'"z\ud834\udd20x"', u'z\ud834\udd20x')
-        assertScan(u'"z\ud834\\udd20x"', u'z%sx' % surrogates)
-        assertScan(u'"z\ud834x"', u'z\ud834x')
+        # surrogates = unichr(0xd834) + unichr(0xdd20)
+        assertScan('"z\\ud834\\u0079x"', 'z\xed\xa0\xb4yx')
+        assertScan('"z\\ud834\\udd20x"', 'z\xed\xa0\xb4\xed\xb4\xa0x')
+        assertScan('"z\\ud834\\ud834\\udd20x"', 'z\xed\xa0\xb4\xed\xa0\xb4\xed\xb4\xa0x')
+        assertScan('"z\\ud834x"', 'z\xed\xa0\xb4x')
+        assertScan('"z\\ud834\udd20x12345"', 'z\xed\xa0\xb4\xed\xb4\xa0x12345')
+        assertScan('"z\\udd20x"', 'z\xed\xb4\xa0x')
+        assertScan('"z\ud834\udd20x"', 'z\xed\xa0\xb4\xed\xb4\xa0x')
+        assertScan('"z\ud834\\udd20x"', 'z\xed\xa0\xb4\xed\xb4\xa0x')
+        assertScan('"z\ud834x"', 'z\xed\xa0\xb4x')
 
     def test_bad_escapes(self):
         scanstring = self.json.decoder.scanstring

--- a/p3json/test/test_unicode.py
+++ b/p3json/test/test_unicode.py
@@ -50,13 +50,15 @@ class TestUnicode(object):
     def test_big_unicode_decode(self):
         u = u'z\U0001d120x'
         self.assertEqual(self.loads('"' + u + '"'), u)
-        self.assertEqual(self.loads('"z\\ud834\\udd20x"'), u)
+        # XXX for python2 json compatibility: output is utf-8
+        self.assertEqual(self.loads('"z\\ud834\\udd20x"'), 'z\xed\xa0\xb4\xed\xb4\xa0x')
 
     def test_unicode_decode(self):
         for i in range(0, 0xd7ff):
             u = unichr(i)
             s = '"\\u{0:04x}"'.format(i)
-            self.assertEqual(self.loads(s), u)
+            # XXX for python2 json compatibility: output is utf-8
+            self.assertEqual(self.loads(s), u.encode('utf-8'))
 
     def test_object_pairs_hook_with_unicode(self):
         s = u'{"xkd":1, "kcw":2, "art":3, "hxm":4, "qrt":5, "pad":6, "hoy":7}'

--- a/p3json/test/test_unicode2.py
+++ b/p3json/test/test_unicode2.py
@@ -37,11 +37,11 @@ class TestS2Cases(object):
                 ('"\\/\xb6\xd4."', '/\xb6\xd4.'),
                 ('"\xe6\x88\x91"', '我'),
 
-                # unicode is loaded as unicode
-                ('"abc\\u6211"', u'abc我'),
+                # unicode is loaded and encoded in utf-8
+                ('"abc\\u6211"', 'abc\xe6\x88\x91'),
 
                 ('{"我": "我"}', {'我':'我'}),
-                ('{"\\u6211": "\\u6211"}', {u'我': u'我'}),
+                ('{"\\u6211": "\\u6211"}', {u'我'.encode('utf-8'): u'我'.encode('utf-8')}),
         ]
 
         for inp, expected in cases:

--- a/utfjson/test/test_utfjson.py
+++ b/utfjson/test/test_utfjson.py
@@ -13,18 +13,18 @@ class TestUTFJson(unittest.TestCase):
         self.assertEqual(None, utfjson.load(None))
         self.assertEqual({}, utfjson.load('{}'))
 
-        # load unicode, result in unicode
+        # load unicode, result in utf-8
 
-        self.assertEqual('我'.decode('utf-8'), utfjson.load('"\\u6211"'))
-        self.assertEqual(unicode,         type(utfjson.load('"\\u6211"')))
+        self.assertEqual('我',      utfjson.load('"\\u6211"'))
+        self.assertEqual(str,  type(utfjson.load('"\\u6211"')))
 
         # unicode and string in a dictionary.
 
         obj = '{"a": "\\u6211", "b": "1"}'
         rst = utfjson.load(obj)
 
-        self.assertEqual({"a": u"\u6211", "b": "1"}, rst)
-        self.assertEqual(unicode, type(rst["a"]))
+        self.assertEqual({"a": "\xe6\x88\x91", "b": "1"}, rst)
+        self.assertEqual(str, type(rst["a"]))
         self.assertEqual(str, type(rst["b"]))
 
         # load utf-8, result in str
@@ -51,7 +51,7 @@ class TestUTFJson(unittest.TestCase):
         self.assertEqual(u'我', utfjson.load('"我"', encoding='utf-8'))
         self.assertEqual(unicode, type(utfjson.load('"我"', encoding='utf-8')))
 
-        self.assertEqual({'a': u"我"}, utfjson.load('{"a": "\\u6211"}'))
+        self.assertEqual({'a': u"我".encode('utf-8')}, utfjson.load('{"a": "\\u6211"}'))
         self.assertEqual({'a': u"我"}, utfjson.load('{"a": "我"}', encoding='utf-8'))
         self.assertEqual({'a':  "我"}, utfjson.load('{"a": "我"}'))
         self.assertEqual({'a':  "我"}, utfjson.load('{"a": "我"}'))
@@ -87,3 +87,6 @@ class TestUTFJson(unittest.TestCase):
         self.assertEqual('{"\\u6211": "\\u6211"}', utfjson.dump({u"我": u"我"}, encoding=None))
 
         self.assertEqual('"\\""', utfjson.dump('"'))
+
+        # encoded chars and unicode chars in one string
+        self.assertEqual('/aaa\xe7\x89\x88\xe6\x9c\xac/jfkdsl\x01', utfjson.load('"\/aaa\xe7\x89\x88\xe6\x9c\xac\/jfkdsl\u0001"'))


### PR DESCRIPTION
This way invalid encoded chars does not break json-load