### PR TITLE
Fix: change thread-num for object-method

### DIFF
--- a/jobq/README.md
+++ b/jobq/README.md
@@ -166,6 +166,7 @@ stat returned format is:
         {
             'name': 'example.worker_foo',
             'input': {'size': 3, 'capa': 1024},
+            'nr_worker': 2,
             'coordinator': {'size': 3, 'capa': 1024}, # presents only when keep_order=True
         },
         ...

--- a/jobq/test/test_jobq.py
+++ b/jobq/test/test_jobq.py
@@ -288,11 +288,8 @@ class TestJobManager(unittest.TestCase):
                 pass
 
         x = X()
-        meth = x.meth
 
-        rst = []
-
-        jm = jobq.JobManager([meth, rst.append])
+        jm = jobq.JobManager([x.meth])
 
         before = jm.stat()
         self.assertEqual(1, before['workers'][0]['nr_worker'])


### PR DESCRIPTION
-   fix set_thread_num with object method:

    ```
    jm = jobq.JobManager([foo_obj.meth])
    jm.set_thread_num(foo_obj.meth)
    ```

    The above code snippet does not work because every time to retrieve a
    object method python creates a new bound method.
    It is an issue in python2.x

-   fix stat():

    If a worker function is a builtin method, stat() should not use its
    `__module__` attribute.