### PR TITLE
dictutil attrdict copy

### DIFF
--- a/dictutil/README.md
+++ b/dictutil/README.md
@@ -7,13 +7,14 @@
 - [Synopsis](#synopsis)
 - [Methods](#methods)
   - [dictutil.attrdict](#dictutilattrdict)
+  - [dictutil.attrdict_copy](#dictutilattrdict_copy)
   - [dictutil.depth_iter](#dictutildepth_iter)
   - [dictutil.breadth_iter](#dictutilbreadth_iter)
   - [dictutil.get](#dictutilget)
   - [dictutil.make_getter](#dictutilmake_getter)
   - [dictutil.make_setter](#dictutilmake_setter)
     - [Synopsis](#synopsis-1)
-  - [dictutil.contians](#dictutilcontains)
+  - [dictutil.contains](#dictutilcontains)
 - [Author](#author)
 - [Copyright and License](#copyright-and-license)
 
@@ -174,6 +175,17 @@ are same as `dict()`, a dictionary or kwargs are both acceptable.
 
 **return**:
 an object provides with dictionary item access with attribute.
+
+
+##  dictutil.attrdict_copy
+
+Same as `dictutil.attrdict`, except that:
+
+-   every time to access it by an attribute or by a key,
+    the value is copied before returning.
+
+-   It does not allow to set its attribute or key, such as `a["x"]=1` or `a.x=1`.
+
 
 ## dictutil.depth_iter
 

--- a/dictutil/__init__.py
+++ b/dictutil/__init__.py
@@ -1,5 +1,6 @@
 from .dictutil import (
     attrdict,
+    attrdict_copy,
     breadth_iter,
     depth_iter,
     get,
@@ -9,10 +10,12 @@ from .dictutil import (
     contains,
 
     AttrDict,
+    AttrDictCopy,
 )
 
 __all__ = [
     "attrdict",
+    "attrdict_copy",
     "breadth_iter",
     "depth_iter",
     "get",
@@ -22,4 +25,5 @@ __all__ = [
     "contains",
 
     "AttrDict",
+    "AttrDictCopy",
 ]

--- a/script/pyauto.sh
+++ b/script/pyauto.sh
@@ -6,7 +6,9 @@ path="${1-.}"
 
 fns="$(find "$path" -name "*.py" -exec echo '"{}"' \;)"
 
+autopep8_options='--max-line-length 120'
+
 eval pyflakes                              $fns
-eval autopep8  -i                          $fns
+eval autopep8  -i $autopep8_options        $fns
 eval autoflake -i                          $fns
 eval isort     --force-single-line-imports $fns


### PR DESCRIPTION
dictutil.attrdict_copy() creates an dictionary whose keys can be access by attribute, in a read-only way.
Every time accessing a value, it makes a deep-copy of the value.
This prevent from incautious modification on a referenced value. Like accessing a global conf dictionary. 

```
ad = dictutil.attrdict_copy(a={"x":3})
print ad.a is ad.a
# False
```