### PR TITLE
strutil: add common_prefix() to find common_prefixes

### DIFF
--- a/strutil/README.md
+++ b/strutil/README.md
@@ -13,6 +13,7 @@
   - [strutil.break_line](#strutilbreak_line)
   - [strutil.color](#strutilcolor)
   - [strutil.colorize](#strutilcolorize)
+  - [strutil.common_prefix](#strutilcommon_prefix)
   - [strutil.line_pad](#strutilline_pad)
   - [strutil.format_line](#strutilformat_line)
   - [strutil.struct_repr](#strutilstruct_repr)
@@ -278,6 +279,36 @@ print colorize(22, 100, '{0:>3}%')
 
 **return**:
 A colored formatted percent string.
+
+
+##  strutil.common_prefix
+
+Find common prefix of several `string`s, tuples of string, or other nested
+structure, recursively.
+It returns the shortest prefix: empty string or empty tuple is removed.
+
+**Synopsis**:
+
+```python
+from pykit import strutil
+
+strutil.common_prefix('abc', 'abd')                   # 'ab'
+strutil.common_prefix((1, 2, 'abc'), (1, 2, 'abd'))   # (1, 2, 'ab')
+strutil.common_prefix((1, 2, 'abc'), (1, 2, 'xyz'))   # (1, 2); empty prefix of 'abc' and 'xyz' is removed
+strutil.common_prefix((1, 2, (5, 6)), (1, 2, (5, 7))) # (1, 2, (5,) )
+strutil.common_prefix('abc', 'abd', 'abe')            # 'ab'; common prefix of more than two
+```
+
+**syntax**:
+`strutil.common_prefix(a, *others)`
+
+**arguments**:
+
+-   `a` and element in `others`:
+    are `string`, `tuple` or `list` to find common prefix of them.
+
+**return**:
+a common prefix of the same type of `a`.
 
 
 ## strutil.line_pad

--- a/strutil/__init__.py
+++ b/strutil/__init__.py
@@ -1,4 +1,5 @@
 from .strutil import (
+    common_prefix,
     format_line,
     line_pad,
     tokenize,
@@ -30,6 +31,7 @@ from .strutil import (
 )
 
 __all__ = [
+    'common_prefix',
     'format_line',
     'line_pad',
     'tokenize',

--- a/strutil/strutil.py
+++ b/strutil/strutil.py
@@ -437,6 +437,53 @@ def utf8str(s):
         return str(s)
 
 
+def common_prefix(a, *others):
+
+    for b in others:
+        if type(a) != type(b):
+            raise TypeError('a and b has different type: ' + repr((a, b)))
+        a = _common_prefix(a, b)
+
+    return a
+
+
+def _common_prefix(a, b):
+
+    rst = []
+    for i, elt in enumerate(a):
+        if i == len(b):
+            break
+
+        if type(elt) != type(b[i]):
+            raise TypeError('a and b has different type: ' + repr((elt, b[i])))
+
+        if elt == b[i]:
+            rst.append(elt)
+        else:
+            break
+
+    # Find common prefix of the last different element.
+    #
+    # string does not support nesting level reduction. It infinitely recurses
+    # down.
+    # And non-iterable element is skipped, such as int.
+    i = len(rst)
+    if i < len(a) and i < len(b) and not isinstance(a, basestring) and hasattr(a[i], '__len__'):
+
+        last_prefix = _common_prefix(a[i], b[i])
+
+        # discard empty tuple, list or string
+        if len(last_prefix) > 0:
+            rst.append(last_prefix)
+
+    if isinstance(a, tuple):
+        return tuple(rst)
+    elif isinstance(a, list):
+        return rst
+    else:
+        return ''.join(rst)
+
+
 def colorize(percent, total=100, ptn='{0}'):
     if total > 0:
         color = fading_color(percent, total)

--- a/strutil/test/test_strutil.py
+++ b/strutil/test/test_strutil.py
@@ -113,6 +113,118 @@ class TestStrutil(unittest.TestCase):
             dd('out: ', rst)
             self.assertEqual(rst, rst_expected)
 
+    def test_common_prefix_invalid_arg(self):
+        cases = (
+            (1, []),
+            ('a', 1),
+            ('a', True),
+            ('a', ('a',)),
+            (('a', (),), ('a', 2,)),
+        )
+
+        for a, b in cases:
+            dd('wrong type: ', repr(a), ' ', repr(b))
+            self.assertRaises(TypeError, strutil.common_prefix, a, b)
+
+    def test_common_prefix(self):
+        cases = (
+            ('abc',
+             'abc',
+             ),
+            ('',
+             '',
+             '',
+             ),
+            ((),
+             (),
+             (),
+             (),
+             ),
+            ('abc',
+             'ab',
+             'ab',
+             ),
+            ('ab',
+             'abd',
+             'ab',
+             ),
+            ('abc',
+             'abd',
+             'ab',
+             ),
+            ('abc',
+             'def',
+             '',
+             ),
+            ('abc',
+             '',
+             '',
+             ),
+            ('',
+             'def',
+             '',
+             ),
+            ('abc',
+             'abd',
+             'ag',
+             'a',
+             ),
+            ('abc',
+             'abd',
+             'ag',
+             'yz',
+             '',
+             ),
+            ((1, 2,),
+             (1, 3,),
+             (1,),
+             ),
+            ((1, 2,),
+             (2, 3,),
+             (),
+             ),
+            ((1, 2, 'abc', ),
+             (1, 2, 'abd', ),
+             (1, 2, 'ab', ),
+             ),
+            ((1, 2, 'abc', ),
+             (1, 2, 'xyz', ),
+             (1, 2, ),
+             ),
+            ((1, 2, (5, 6), ),
+             (1, 2, (5, 7), ),
+             (1, 2, (5,), ),
+             ),
+            (('abc', '45',),
+             ('abc', '46', 'xyz'),
+             ('abc', '4',),
+             ),
+            (('abc', ('45', 'xyz'), 3),
+             ('abc', ('45', 'xz'), 5),
+             ('abc', ('45', 'x-'), 5),
+             ('abc', ('45', 'x'),),
+             ),
+            (('abc', ('45', 'xyz'), 3),
+             ('abc', ('45', 'xz'), 5),
+             ('abc', ('x',),),
+             ('abc',),
+             ),
+            ([1, 2, 3],
+             [1, 2, 4],
+             [1, 2],
+            ),
+        )
+
+        for args in cases:
+            expected = args[-1]
+            args = args[:-1]
+
+            dd('input: ', args, 'expected: ', expected)
+            rst = strutil.common_prefix(*args)
+            dd('rst: ', rst)
+
+            self.assertEqual(expected, rst)
+
     def test_line_pad(self):
 
         cases = (


### PR DESCRIPTION
Find common prefix of several serias, recursively.
It returns the shortest prefix: empty string or empty tuple is removed.

    from pykit import strutil

    strutil.common_prefix('abc', 'abd')                   # 'ab'
    strutil.common_prefix((1, 2, 'abc'), (1, 2, 'abd'))   # (1, 2, 'ab')
    strutil.common_prefix((1, 2, 'abc'), (1, 2, 'xyz'))   # (1, 2); empty prefix of 'abc' and 'xyz' is removed
    strutil.common_prefix((1, 2, (5, 6)), (1, 2, (5, 7))) # (1, 2, (5,) )