### PR TITLE
jobq: add dispatcher support: define how to disptach jobs to worker t…

### DIFF
--- a/jobq/README.md
+++ b/jobq/README.md
@@ -110,7 +110,8 @@ Process element from input one by one with functions in workers.
     can be used in a for-loop.
 
 -   `workers`:
-    list of functions, or `tuple` of `(function, nr_of_thread)`.
+    list of functions, or `tuple` of `(function, nr_of_thread)`,
+    or `tuple` of `(function, nr_of_thread, dispatcher_func)`.
 
     A worker must accept one argument and return one value.
     A typical worker would be defined like:
@@ -129,6 +130,29 @@ Process element from input one by one with functions in workers.
         for elt in args:
             yield elt
     ```
+
+    A `dispatcher` is specified by user to control how to dispatch args to
+    different workers.
+    It should accept one argument `args`, same as the `args` passed to a worker
+    function,  and return a `int` indicating which worker to used.
+
+    A dispatcher function might be defined like:
+
+    ```
+    def dispatch(args):
+        return hash(args) % 5
+    ```
+
+    A user-defined dipatcher is used when **concurrency** and **partial-order**
+    are both required:
+    -   The `args` passed to a same worker is guaranteed to be
+        executed in order.
+    -   Different workers still run multiple tasks concurrently.
+
+    **If a `dispatcher` specified, it implies `keep_order=True`**.
+
+    Thus a worker group with dispatcher also put result into input queue of next
+    worker group with order kept.
 
 -   `keep_order`:
     specifies whether elements must be processed in order.

--- a/jobq/test/test_jobq.py
+++ b/jobq/test/test_jobq.py
@@ -6,6 +6,9 @@ import unittest
 
 from pykit import jobq
 from pykit import threadutil
+from pykit import ututil
+
+dd = ututil.dd
 
 
 def add1(args):
@@ -136,6 +139,100 @@ class TestProbe(unittest.TestCase):
         self.assertEqual(2, len(workers))
 
         th.join()
+
+
+class TestDispatcher(unittest.TestCase):
+
+    def test_dispatcher_job_manager(self):
+
+        n_threads = 3
+        n_numbers = 1000
+        rst = {}
+        ordered = []
+
+        def _collect_by_tid(ii):
+
+            tid = threading.current_thread().ident
+            if tid not in rst:
+                rst[tid] = []
+
+            rst[tid].append(ii)
+            return ii
+
+        def _collect(ii):
+            ordered.append(ii)
+
+        jm = jobq.JobManager([
+            (_collect_by_tid, n_threads, lambda x: x % n_threads),
+            (_collect, 1),
+        ])
+
+        # In dispatcher mode it does not allow to set thread_num to prevent out
+        # of order output
+        self.assertRaises(jobq.JobWorkerError, jm.set_thread_num, _collect_by_tid, 10)
+
+        for i in range(n_numbers):
+            jm.put(i)
+
+            st = jm.stat()
+            dd(st)
+
+            self.assertIn('dispatcher', st['workers'][0])
+            dstat = st['workers'][0]['dispatcher']
+            self.assertEqual(n_threads, len(dstat))
+            for ds in dstat:
+                self.assertIn('input', ds)
+                self.assertIn('output', ds)
+
+        jm.join()
+
+        self.assertEqual(n_threads, len(rst.keys()))
+
+        for arr in rst.values():
+            m = arr[0] % n_threads
+            for i in arr:
+                # a thread receives args with the same mod by `n_threads`
+                self.assertEqual(m, i % n_threads)
+
+        # with dispatcher, output are ordered
+        self.assertEqual([x for x in range(n_numbers)],
+                         ordered)
+
+    def test_dispatcher_run(self):
+
+        n_threads = 3
+        n_numbers = 1000
+        rst = {}
+        ordered = []
+
+        def _collect_by_tid(ii):
+
+            tid = threading.current_thread().ident
+            if tid not in rst:
+                rst[tid] = []
+
+            rst[tid].append(ii)
+            return ii
+
+        def _collect(ii):
+            ordered.append(ii)
+
+        jobq.run(range(n_numbers), [
+            (_collect_by_tid, n_threads, lambda x: x % n_threads),
+            (_collect, 1),
+        ])
+
+        self.assertEqual(n_threads, len(rst.keys()))
+
+        for arr in rst.values():
+            m = arr[0] % n_threads
+            for i in arr:
+                # a thread receives args with the same mod by `n_threads`
+                self.assertEqual(m, i % n_threads)
+
+        # with dispatcher, output are ordered
+        self.assertEqual([x for x in range(n_numbers)],
+                         ordered)
 
 
 class TestTimeout(unittest.TestCase):


### PR DESCRIPTION
…hreads: run(range(10), [(func, n, lambda x: x % 3)])

这个功能是用在db拆表时保证顺序的并发插入目标数据库用的.