### PR TITLE
wsjobd use jobq to parse request

### DIFF
--- a/wsjobd/README.md
+++ b/wsjobd/README.md
@@ -29,10 +29,7 @@ from geventwebsocket import Resource, WebSocketServer
 from pykit import wsjobd
 
 def run():
-    WebSocketServer(
-        ('127.0.0.1', 33445),
-        Resource(OrderedDict({'/': wsjobd.JobdWebSocketApplication})),
-    ).serve_forever()
+    wsjobd.run(ip='127.0.0.1', port=33445)
 
 if __name__ == "__main__":
     logger = logging.getLogger()

--- a/wsjobd/test/wsjobd_server.py
+++ b/wsjobd/test/wsjobd_server.py
@@ -1,21 +1,13 @@
 #!/usr/bin/env python2
 # coding: utf-8
 import logging
-from collections import OrderedDict
-
-from geventwebsocket import Resource
-from geventwebsocket import WebSocketServer
-
 from pykit import wsjobd
 
 PORT = 33445
 
 
 def run():
-    WebSocketServer(
-        ('127.0.0.1', PORT),
-        Resource(OrderedDict({'/': wsjobd.JobdWebSocketApplication})),
-    ).serve_forever()
+    wsjobd.run(ip='127.0.0.1', port=PORT, jobq_thread_count=20)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
由于gevent使用协程accept客户端链接请求，导致connect请求是串行处理。请求过多导致链接时间过长。采用jobq解决这个问题。